### PR TITLE
Issue/22 - Set up content model event

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,9 @@
         "phpstan/phpstan": "^1.9",
         "friendsofphp/php-cs-fixer": "^3.13",
         "phpunit/phpunit": "^9.5",
-        "mockery/mockery": "^1.5"
+        "mockery/mockery": "^1.5",
+        "phpstan/phpstan-mockery": "^1.1",
+        "phpstan/extension-installer": "^1.2"
     },
     "require": {
         "underpin/underpin": "^3.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3eac988d5c1a7c8403089dd55229d694",
+    "content-hash": "bb87da78a3e468fc5f0a71e4e36def76",
     "packages": [
         {
             "name": "composer/installers",
@@ -1074,6 +1074,50 @@
             "time": "2022-02-21T01:04:05+00:00"
         },
         {
+            "name": "phpstan/extension-installer",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/extension-installer.git",
+                "reference": "f06dbb052ddc394e7896fcd1cfcd533f9f6ace40"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/extension-installer/zipball/f06dbb052ddc394e7896fcd1cfcd533f9f6ace40",
+                "reference": "f06dbb052ddc394e7896fcd1cfcd533f9f6ace40",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.0",
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpstan": "^1.8.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2.0",
+                "phpstan/phpstan-strict-rules": "^0.11 || ^0.12 || ^1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PHPStan\\ExtensionInstaller\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\ExtensionInstaller\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Composer plugin for automatic installation of PHPStan extensions",
+            "support": {
+                "issues": "https://github.com/phpstan/extension-installer/issues",
+                "source": "https://github.com/phpstan/extension-installer/tree/1.2.0"
+            },
+            "time": "2022-10-17T12:59:16+00:00"
+        },
+        {
             "name": "phpstan/phpstan",
             "version": "1.9.2",
             "source": {
@@ -1131,6 +1175,56 @@
                 }
             ],
             "time": "2022-11-10T09:56:11+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-mockery",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-mockery.git",
+                "reference": "245b17ccd00f04be3c6b9fc6645f63793b37b2ea"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-mockery/zipball/245b17ccd00f04be3c6b9fc6645f63793b37b2ea",
+                "reference": "245b17ccd00f04be3c6b9fc6645f63793b37b2ea",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpstan": "^1.5.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.2.4",
+                "nikic/php-parser": "^4.13.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/phpstan-phpunit": "^1.0",
+                "phpstan/phpstan-strict-rules": "^1.0",
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan Mockery extension",
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan-mockery/issues",
+                "source": "https://github.com/phpstan/phpstan-mockery/tree/1.1.0"
+            },
+            "time": "2022-05-09T13:12:35+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/lib/Events/Content_Model_Event.php
+++ b/lib/Events/Content_Model_Event.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Adiungo\Core\Events;
+
+
+use Adiungo\Core\Events\Providers\Content_Model_Provider;
+use Underpin\Exceptions\Operation_Failed;
+use Underpin\Exceptions\Unknown_Registry_Item;
+use Underpin\Interfaces\Singleton;
+use Underpin\Traits\With_Broadcaster;
+use Underpin\Traits\With_Instance;
+
+class Content_Model_Event implements Singleton
+{
+    use With_Broadcaster;
+    use With_Instance;
+
+    /**
+     * Attach a callback to the specified model action.
+     *
+     * @param string $model The model class name, EG: Model::class
+     * @param string $action The action, such as "save" or "delete"
+     * @param callable $callback The function to call when this action is broadcasted.
+     * @return void
+     * @throws Operation_Failed
+     * @throws Unknown_Registry_Item
+     */
+    public function attach(string $model, string $action, callable $callback): void
+    {
+        $this->get_broadcaster()->attach($this->get_broadcaster_key($model, $action), $callback);
+    }
+
+    /**
+     * Generates a model key using the provided arguments.
+     *
+     * @param string $model The model class name, EG: Model::class
+     * @param string $action The action.
+     * @return string The model key.
+     */
+    protected function get_broadcaster_key(string $model, string $action): string
+    {
+        return $model . '__' . $action;
+    }
+
+    /**
+     * Detach a callback from the specified model action.
+     *
+     * @param string $model The model class name, EG: Model::class
+     * @param string $action The action, such as "save" or "delete"
+     * @param callable $callback The function to prevent from calling when this action is broadcasted.
+     * @return void
+     * @throws Operation_Failed
+     */
+    public function detach(string $model, string $action, callable $callback): void
+    {
+        $this->get_broadcaster()->detach($this->get_broadcaster_key($model, $action), $callback);
+    }
+
+    /**
+     * @param string $action The action, such as "save" or "delete"
+     * @param Content_Model_Provider $provider The model provider containing the model that is being broadcasted.
+     * @return void
+     */
+    public function broadcast(string $action, Content_Model_Provider $provider): void
+    {
+        $this->get_broadcaster()->broadcast($this->get_broadcaster_key($provider->get_model()::class, $action), $provider);
+    }
+}

--- a/tests/Traits/With_Inaccessible_Methods.php
+++ b/tests/Traits/With_Inaccessible_Methods.php
@@ -11,7 +11,7 @@ trait With_Inaccessible_Methods
     /**
      * @throws ReflectionException
      */
-    protected function call_inaccessible_method($object, $method_name, ...$args)
+    protected function call_inaccessible_method(object $object, string $method_name, mixed ...$args): mixed
     {
         $reflection = new ReflectionClass(get_class($object));
         $method = $reflection->getMethod($method_name);

--- a/tests/Traits/With_Inaccessible_Methods.php
+++ b/tests/Traits/With_Inaccessible_Methods.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Adiungo\Core\Tests\Traits;
+
+use ReflectionClass;
+use ReflectionException;
+
+trait With_Inaccessible_Methods
+{
+
+    /**
+     * @throws ReflectionException
+     */
+    protected function call_inaccessible_method($object, $method_name, ...$args)
+    {
+        $reflection = new ReflectionClass(get_class($object));
+        $method = $reflection->getMethod($method_name);
+        /** @noinspection PhpExpressionResultUnusedInspection */
+        $method->setAccessible(true);
+
+        return $method->invokeArgs($object, $args);
+    }
+
+}

--- a/tests/Unit/Events/Content_Model_Event_Test.php
+++ b/tests/Unit/Events/Content_Model_Event_Test.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Adiungo\Core\Tests\Unit\Events;
+
+
+use Adiungo\Core\Abstracts\Content_Model;
+use Adiungo\Core\Events\Content_Model_Event;
+use Adiungo\Core\Events\Providers\Content_Model_Provider;
+use Adiungo\Core\Tests\Test_Case;
+use Adiungo\Core\Tests\Traits\With_Inaccessible_Methods;
+use Mockery;
+use ReflectionException;
+use Underpin\Exceptions\Operation_Failed;
+use Underpin\Exceptions\Unknown_Registry_Item;
+
+class Content_Model_Event_Test extends Test_Case
+{
+    use With_Inaccessible_Methods;
+
+    /**
+     * @covers \Adiungo\Core\Events\Content_Model_Event::get_broadcaster_key
+     *
+     * @return void
+     * @throws ReflectionException
+     */
+    public function test_can_get_broadcaster_key(): void
+    {
+        $instance = new Content_Model_Event();
+
+        $this->assertEquals('Model_Foo_Bar_Baz__save', $this->call_inaccessible_method($instance, 'get_broadcaster_key', 'Model_Foo_Bar_Baz', 'save'));
+    }
+
+    /**
+     * @covers \Adiungo\Core\Events\Content_Model_Event::attach
+     *
+     * @return void
+     * @throws Unknown_Registry_Item
+     * @throws Operation_Failed
+     */
+    public function test_can_attach(): void
+    {
+        $instance = Mockery::mock(Content_Model_Event::class);
+        $instance->shouldAllowMockingProtectedMethods()->makePartial();
+        $model = 'Model_Custom';
+        $action = 'delete';
+        $callback = fn() => '';
+
+        $instance->allows('get_broadcaster_key')->with($model, $action)->andReturn('foo');
+        $instance->expects('get_broadcaster->attach')->with('foo', $callback);
+
+        $instance->attach($model, $action, $callback);
+    }
+
+    /**
+     * @covers \Adiungo\Core\Events\Content_Model_Event::attach
+     *
+     * @return void
+     * @throws Operation_Failed
+     */
+    public function test_can_detach(): void
+    {
+        $instance = Mockery::mock(Content_Model_Event::class);
+        $instance->shouldAllowMockingProtectedMethods()->makePartial();
+        $model = 'Model_Custom';
+        $action = 'delete';
+        $callback = fn() => '';
+
+        $instance->allows('get_broadcaster_key')->with($model, $action)->andReturn('foo');
+        $instance->expects('get_broadcaster->detach')->with('foo', $callback);
+
+        $instance->detach($model, $action, $callback);
+    }
+
+    /**
+     * @covers \Adiungo\Core\Events\Content_Model_Event::broadcast
+     *
+     * @return void
+     */
+    public function test_can_broadcast(): void
+    {
+        $instance = Mockery::mock(Content_Model_Event::class);
+        $instance->shouldAllowMockingProtectedMethods()->makePartial();
+
+        $model = Mockery::mock(Content_Model::class);
+
+        $provider = new Content_Model_Provider($model);
+        $action = 'delete';
+
+        $instance->allows('get_broadcaster_key')->with($model::class, $action)->andReturn('foo');
+        $instance->expects('get_broadcaster->broadcast')->with('foo', $provider);
+
+        $instance->broadcast($action, $provider);
+    }
+
+}


### PR DESCRIPTION
## Summary

Resolves #22
This PR implements the `Content_Model_Event` class, methods, and tests.

## Details

I also added some helpers related to unit tests to make testing easier in the future, as well as installed a couple dev-specific packages to make PHPStan cooperate with Mockery a little more reliably.

## Before Marking this PR as Ready to Review, I have verified that:

- [x] This PR fulfills the acceptance criteria detailed in the issue.
- [x] This PR matches the coding standards.
- [x] Related unit tests have been written, or updated to reflect the changes here.
- [x] All tests have passed.
- [x] I have filled out the "Testing" section with detailed instructions on how to test this PR
- [x] I have assigned this PR to myself
- [x] I have linked this PR to the issue it is intended to close.

## Before Merge, the Reviewer has verified that:

- [x] This PR fulfills the acceptance criteria detailed in the issue.
- [x] This PR matches the coding standards.
- [x] All unit tests have passed.
- [x] The code has been reviewed.
- [x] Any changes to the code has been appropriately covered in unit tests.