### PR TITLE
Issue/28 - Sets up Queue_Index_Event and tests

### DIFF
--- a/lib/Abstracts/Index_Strategy_Builder.php
+++ b/lib/Abstracts/Index_Strategy_Builder.php
@@ -10,5 +10,5 @@ abstract class Index_Strategy_Builder implements Has_Index_Strategy
 {
     use With_Index_Strategy;
 
-    abstract protected function get_model(): string;
+    abstract public function get_model(): string;
 }

--- a/lib/Events/Queue_Index_Event.php
+++ b/lib/Events/Queue_Index_Event.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Adiungo\Core\Events;
+
+
+use Adiungo\Core\Abstracts\Index_Strategy_Builder;
+use Adiungo\Core\Events\Providers\Index_Strategy_Provider;
+use Underpin\Exceptions\Operation_Failed;
+use Underpin\Exceptions\Unknown_Registry_Item;
+use Underpin\Interfaces\Singleton;
+use Underpin\Traits\With_Broadcaster;
+use Underpin\Traits\With_Instance;
+
+class Queue_Index_Event implements Singleton
+{
+    use With_Instance;
+    use With_Broadcaster;
+
+    protected function get_broadcaster_key(Index_Strategy_Builder $builder): string
+    {
+        return $builder->get_index_strategy()->get_data_source()::class . '__' . $builder->get_model();
+    }
+
+    /**
+     * Attach a callback to the specified index event.
+     *
+     * @param Index_Strategy_Builder $builder
+     * @param callable $callback
+     * @return void
+     * @throws Operation_Failed
+     * @throws Unknown_Registry_Item
+     */
+    public function attach(Index_Strategy_Builder $builder, callable $callback): void
+    {
+        $this->get_broadcaster()->attach($this->get_broadcaster_key($builder), $callback);
+    }
+
+    /**
+     * Detach a callback from the specified index event.
+     *
+     * @throws Operation_Failed
+     */
+    public function detach(Index_Strategy_Builder $builder, callable $callback): void
+    {
+        $this->get_broadcaster()->detach($this->get_broadcaster_key($builder), $callback);
+    }
+
+    /**
+     * Broadcasts this event.
+     *
+     * @param Index_Strategy_Builder $builder
+     * @return void
+     */
+    public function broadcast(Index_Strategy_Builder $builder): void
+    {
+        $this->get_broadcaster()->broadcast($this->get_broadcaster_key($builder), new Index_Strategy_Provider($builder->get_index_strategy()));
+    }
+}

--- a/lib/Factories/Index_Strategy.php
+++ b/lib/Factories/Index_Strategy.php
@@ -11,11 +11,6 @@ class Index_Strategy implements Has_Data_Source
 {
     use With_Data_Source;
 
-    public function __construct(protected string $model)
-    {
-
-    }
-
     /**
      * Saves the model.
      *

--- a/tests/Unit/Events/Content_Model_Event_Test.php
+++ b/tests/Unit/Events/Content_Model_Event_Test.php
@@ -52,7 +52,7 @@ class Content_Model_Event_Test extends Test_Case
     }
 
     /**
-     * @covers \Adiungo\Core\Events\Content_Model_Event::attach
+     * @covers \Adiungo\Core\Events\Content_Model_Event::detach
      *
      * @return void
      * @throws Operation_Failed

--- a/tests/Unit/Events/Queue_Index_Event_Test.php
+++ b/tests/Unit/Events/Queue_Index_Event_Test.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Adiungo\Core\Tests\Unit\Events;
+
+
+use Adiungo\Core\Abstracts\Index_Strategy_Builder;
+use Adiungo\Core\Events\Providers\Index_Strategy_Provider;
+use Adiungo\Core\Events\Queue_Index_Event;
+use Adiungo\Core\Factories\Index_Strategy;
+use Adiungo\Core\Interfaces\Data_Source;
+use Adiungo\Core\Tests\Test_Case;
+use Adiungo\Core\Tests\Traits\With_Inaccessible_Methods;
+use Mockery;
+use ReflectionException;
+use Underpin\Exceptions\Operation_Failed;
+use Underpin\Exceptions\Unknown_Registry_Item;
+
+class Queue_Index_Event_Test extends Test_Case
+{
+    use With_Inaccessible_Methods;
+
+    /**
+     * @covers \Adiungo\Core\Events\Queue_Index_Event::get_broadcaster_key
+     *
+     * @return void
+     * @throws ReflectionException
+     */
+    public function test_can_get_broadcaster_key(): void
+    {
+        $instance = new Queue_Index_Event();
+        $index_strategy_builder = Mockery::mock(Index_Strategy_Builder::class);
+        $data_source = Mockery::namedMock('Foo', Data_Source::class);
+
+        $index_strategy_builder->allows('get_model')->andReturn('Bar');
+        $index_strategy_builder->allows('get_index_strategy->get_data_source')->andReturn($data_source);
+
+        $this->assertEquals('Foo__Bar', $this->call_inaccessible_method($instance, 'get_broadcaster_key', $index_strategy_builder));
+    }
+
+    /**
+     * @covers \Adiungo\Core\Events\Queue_Index_Event::attach
+     *
+     * @return void
+     * @throws Unknown_Registry_Item
+     * @throws Operation_Failed
+     */
+    public function test_can_attach(): void
+    {
+        $instance = Mockery::mock(Queue_Index_Event::class);
+        $instance->shouldAllowMockingProtectedMethods()->makePartial();
+        $index_strategy_builder = Mockery::mock(Index_Strategy_Builder::class);
+        $callback = fn() => '';
+
+        $instance->allows('get_broadcaster_key')->with($index_strategy_builder)->andReturn('foo');
+        $instance->expects('get_broadcaster->attach')->with('foo', $callback);
+
+        $instance->attach($index_strategy_builder, $callback);
+    }
+
+    /**
+     * @covers \Adiungo\Core\Events\Queue_Index_Event::detach
+     *
+     * @return void
+     * @throws Operation_Failed
+     */
+    public function test_can_detach(): void
+    {
+        $instance = Mockery::mock(Queue_Index_Event::class);
+        $instance->shouldAllowMockingProtectedMethods()->makePartial();
+        $index_strategy_builder = Mockery::mock(Index_Strategy_Builder::class);
+        $callback = fn() => '';
+
+        $instance->allows('get_broadcaster_key')->with($index_strategy_builder)->andReturn('foo');
+        $instance->expects('get_broadcaster->detach')->with('foo', $callback);
+
+        $instance->detach($index_strategy_builder, $callback);
+    }
+
+    /**
+     * @covers \Adiungo\Core\Events\Queue_Index_Event::broadcast
+     *
+     * @return void
+     */
+    public function test_can_broadcast(): void
+    {
+        $instance = Mockery::mock(Queue_Index_Event::class);
+        $instance->shouldAllowMockingProtectedMethods()->makePartial();
+
+        $strategy = Mockery::mock(Index_Strategy::class);
+
+        $index_strategy_builder = Mockery::mock(Index_Strategy_Builder::class);
+        $index_strategy_builder->allows('get_index_strategy')->andReturn($strategy);
+
+        $instance->allows('get_broadcaster_key')->with($index_strategy_builder)->andReturn('foo');
+
+        $instance->expects('get_broadcaster->broadcast')->withArgs(function ($key, $strategy_test) use ($strategy) {
+            return $key === 'foo' && $strategy_test instanceof Index_Strategy_Provider && $strategy_test->get_index_strategy() === $strategy;
+        });
+
+
+        $instance->broadcast($index_strategy_builder);
+    }
+
+}


### PR DESCRIPTION
## Summary

resolves #28 

This sets up the `Queue_Index_Event` class.

## Details

This PR also removes what was deemed to be an un-necessary constructor in `Index_Strategy` and makes some minor tweaks to documentation that was incorrect in another class.

## Before Marking this PR as Ready to Review, I have verified that:

- [x] This PR fulfills the acceptance criteria detailed in the issue.
- [x] This PR matches the coding standards.
- [x] Related unit tests have been written, or updated to reflect the changes here.
- [x] All tests have passed.
- [x] I have filled out the "Testing" section with detailed instructions on how to test this PR
- [x] I have assigned this PR to myself
- [x] I have linked this PR to the issue it is intended to close.

## Before Merge, the Reviewer has verified that:

- [x] This PR fulfills the acceptance criteria detailed in the issue.
- [x] This PR matches the coding standards.
- [x] All unit tests have passed.
- [x] The code has been reviewed.
- [x] Any changes to the code has been appropriately covered in unit tests.