### PR TITLE
Issue 60 - Sets up attachment support

### DIFF
--- a/lib/Collections/Attachment_Collection.php
+++ b/lib/Collections/Attachment_Collection.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Adiungo\Core\Collections;
+
+
+use Adiungo\Core\Interfaces\Attachment;
+use Underpin\Abstracts\Registries\Object_Registry;
+
+class Attachment_Collection extends Object_Registry
+{
+    protected string $abstraction_class = Attachment::class;
+}

--- a/lib/Interfaces/Attachment.php
+++ b/lib/Interfaces/Attachment.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Adiungo\Core\Interfaces;
+
+
+use Underpin\Interfaces\Identifiable_String;
+
+interface Attachment extends Has_Origin, Identifiable_String
+{
+
+}

--- a/lib/Interfaces/Has_Attachments.php
+++ b/lib/Interfaces/Has_Attachments.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Adiungo\Core\Interfaces;
+
+use Adiungo\Core\Collections\Attachment_Collection;
+use Underpin\Exceptions\Operation_Failed;
+
+interface Has_Attachments
+{
+
+    /**
+     * Gets the attachment
+     *
+     * @return Attachment_Collection
+     */
+    public function get_attachments(): Attachment_Collection;
+
+    /**
+     * Sets the attachment
+     *
+     * @param Attachment $attachment The attachment to set.
+     * @param Attachment ...$attachments
+     * @return static
+     * @throws Operation_Failed
+     */
+    public function add_attachments(Attachment $attachment, Attachment ...$attachments): static;
+
+    /**
+     * @param string $id
+     * @param string ...$ids
+     * @return static
+     * @throws Operation_Failed
+     */
+    public function remove_attachments(string $id, string ...$ids): static;
+
+    /**
+     * Returns true if there are any attachments.
+     *
+     * @return bool
+     */
+    public function has_attachments(): bool;
+}

--- a/lib/Traits/With_Attachments.php
+++ b/lib/Traits/With_Attachments.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Adiungo\Core\Traits;
+
+
+namespace Adiungo\Core\Traits;
+
+use Adiungo\Core\Collections\Attachment_Collection;
+use Adiungo\Core\Interfaces\Attachment;
+use Underpin\Exceptions\Operation_Failed;
+
+trait With_Attachments
+{
+
+    protected Attachment_Collection $attachments;
+
+    /**
+     * Sets the attachments
+     *
+     * @param Attachment $attachment
+     * @param Attachment ...$attachments The attachments to set.
+     * @return $this
+     * @throws Operation_Failed
+     */
+    public function add_attachments(Attachment $attachment, Attachment ...$attachments): static
+    {
+        $attachments = func_get_args();
+
+        /** @var Attachment $attachment_item */
+        foreach ($attachments as $attachment_item) {
+            $this->get_attachments()->add((string)$attachment_item->get_id(), $attachment_item);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Gets the attachments
+     *
+     * @return Attachment_Collection
+     */
+    public function get_attachments(): Attachment_Collection
+    {
+        if (!isset($this->attachments)) {
+            $this->attachments = new Attachment_Collection();
+        }
+
+        return $this->attachments;
+    }
+
+    /**
+     * @param string $id
+     * @param string ...$ids
+     * @return static
+     * @throws Operation_Failed
+     */
+    public function remove_attachments(string $id, string ...$ids): static
+    {
+        $all_ids = func_get_args();
+
+        /** @var Attachment_Collection $result */
+        $result = $this->get_attachments()->query()->not_in('id', ...$all_ids)->get_results();
+
+        $this->attachments = $result;
+        return $this;
+    }
+
+    /**
+     * Returns true if this class has any attachments.
+     *
+     * @return bool
+     */
+    public function has_attachments(): bool
+    {
+        return !empty($this->get_attachments()->to_array());
+    }
+
+}

--- a/tests/Unit/Traits/With_Attachments_Test.php
+++ b/tests/Unit/Traits/With_Attachments_Test.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Adiungo\Core\Tests\Unit\Traits;
+
+
+use Adiungo\Core\Collections\Attachment_Collection;
+use Adiungo\Core\Interfaces\Attachment;
+use Adiungo\Core\Interfaces\Has_Attachments;
+use Adiungo\Core\Tests\Test_Case;
+use Adiungo\Core\Traits\With_Attachments;
+use Generator;
+use Mockery;
+use Underpin\Exceptions\Operation_Failed;
+
+class With_Attachments_Test extends Test_Case
+{
+
+    /**
+     * @covers \Adiungo\Core\Traits\With_Attachments::get_attachments
+     * @return void
+     */
+    public function test_can_get_attachments(): void
+    {
+        $this->assertInstanceOf(Attachment_Collection::class, $this->get_instance()->get_attachments());
+    }
+
+    protected function get_instance(): Has_Attachments
+    {
+        return new class implements Has_Attachments {
+            use With_Attachments;
+        };
+    }
+
+    /**
+     * @covers \Adiungo\Core\Traits\With_Attachments::add_attachments
+     * @throws Operation_Failed
+     */
+    public function test_can_add_attachments(): void
+    {
+        $attachment_1 = Mockery::mock(Attachment::class);
+        $attachment_1->allows('get_id')->andReturn('a');
+
+        $attachment_2 = Mockery::mock(Attachment::class);
+        $attachment_2->allows('get_id')->andReturn('b');
+
+        $attachment_3 = Mockery::mock(Attachment::class);
+        $attachment_3->allows('get_id')->andReturn('c');
+
+        $result = $this->get_instance()->add_attachments($attachment_1, $attachment_2, $attachment_3)->get_attachments()->to_array();
+        $this->assertSame(['a' => $attachment_1, 'b' => $attachment_2, 'c' => $attachment_3], $result);
+    }
+
+    /**
+     * @covers       \Adiungo\Core\Traits\With_Attachments::has_attachments
+     * @param bool $expected
+     * @param int $attachment_count
+     * @return void
+     * @throws Operation_Failed
+     * @dataProvider provider_has_attachments
+     */
+    public function test_has_attachments(bool $expected, int $attachment_count): void
+    {
+        $result = $this->get_instance();
+
+        for ($i = 0; $i < $attachment_count; $i++) {
+            $mock = Mockery::mock(Attachment::class);
+            $mock->allows('get_id')->andReturn('item_' . $i);
+            $result->add_attachments($mock);
+        }
+
+        $this->assertSame($expected, $result->has_attachments());
+    }
+
+    /** @see test_has_attachments * */
+    public function provider_has_attachments(): Generator
+    {
+        yield 'No attachments' => [false, 0];
+        yield 'One attachment' => [true, 1];
+        yield 'Two attachments' => [true, 2];
+    }
+
+    /**
+     * @covers \Adiungo\Core\Traits\With_Attachments::remove_attachments
+     * @throws Operation_Failed
+     */
+    public function test_can_remove_attachments(): void
+    {
+        $attachment_1 = Mockery::mock(Attachment::class);
+        $attachment_1->allows('get_id')->andReturn('a');
+
+        $attachment_2 = Mockery::mock(Attachment::class);
+        $attachment_2->allows('get_id')->andReturn('b');
+
+        $attachment_3 = Mockery::mock(Attachment::class);
+        $attachment_3->allows('get_id')->andReturn('c');
+
+        $attachment_4 = Mockery::mock(Attachment::class);
+        $attachment_4->allows('get_id')->andReturn('d');
+
+        $result = $this->get_instance()->add_attachments($attachment_1, $attachment_2, $attachment_3, $attachment_4)->remove_attachments('a', 'b', 'c');
+        $this->assertSame(['d' => $attachment_4], $result->get_attachments()->to_array());
+    }
+}


### PR DESCRIPTION
## Summary

Resolves #60 

## Details

This PR got a little bigger because I ended up embedding support for multiple attachments now. I realized that many imported content items can contain multiple attachments (Twitter, for example, can attach multiple images).

## Before Marking this PR as Ready to Review, I have verified that:

- [x] This PR fulfills the acceptance criteria detailed in the issue.
- [x] This PR matches the coding standards.
- [x] Related unit tests have been written, or updated to reflect the changes here.
- [x] All tests have passed.
- [x] I have filled out the "Testing" section with detailed instructions on how to test this PR
- [x] I have assigned this PR to myself
- [x] I have linked this PR to the issue it is intended to close.

## Before Merge, the Reviewer has verified that:

- [x] This PR fulfills the acceptance criteria detailed in the issue.
- [x] This PR matches the coding standards.
- [x] All unit tests have passed.
- [x] The code has been reviewed.
- [x] Any changes to the code has been appropriately covered in unit tests.