### PR TITLE
Issue/74 Adds support for indexing a single model.

### DIFF
--- a/lib/Factories/Index_Strategy.php
+++ b/lib/Factories/Index_Strategy.php
@@ -31,4 +31,15 @@ class Index_Strategy implements Has_Data_Source
     {
         $this->get_data_source()->get_data()->each([$this, 'save_item']);
     }
+
+    /**
+     * Saves a single index item.
+     *
+     * @param string|int $id
+     * @return void
+     */
+    public function index_item(string|int $id): void
+    {
+        $this->save_item($this->get_data_source()->get_item($id));
+    }
 }

--- a/lib/Interfaces/Data_Source.php
+++ b/lib/Interfaces/Data_Source.php
@@ -2,6 +2,7 @@
 
 namespace Adiungo\Core\Interfaces;
 
+use Adiungo\Core\Abstracts\Content_Model;
 use Adiungo\Core\Collections\Content_Model_Collection;
 
 interface Data_Source
@@ -27,4 +28,12 @@ interface Data_Source
      * @return Data_Source
      */
     public function get_next(): Data_Source;
+
+    /**
+     * Gets a single content model from the data source.
+     *
+     * @param string|int $id
+     * @return Content_Model
+     */
+    public function get_item(string|int $id): Content_Model;
 }

--- a/tests/Unit/Factories/Index_Strategy_Test.php
+++ b/tests/Unit/Factories/Index_Strategy_Test.php
@@ -44,4 +44,20 @@ class Index_Strategy_Test extends Test_Case
         $this->call_inaccessible_method($mock, 'save_item', $model);
     }
 
+    /**
+     * @covers \Adiungo\Core\Factories\Index_Strategy::index_item
+     *
+     * @return void
+     */
+    public function test_can_index_item(): void
+    {
+        $id = 123;
+        $mock = Mockery::mock(Index_Strategy::class)->makePartial()->shouldAllowMockingProtectedMethods();
+        $model = Mockery::mock(Content_Model::class);
+
+        $mock->expects('get_data_source->get_item')->with($id)->once()->andReturn($model);
+        $mock->expects('save_item')->with($model);
+
+        $mock->index_item($id);
+    }
 }


### PR DESCRIPTION
## Summary

Resolves #74 

This PR implements two new methods, `Data_Source::get_item` and `Index_Strategy::index_item`. These methods make it possible to index a single model using an index strategy.

## Before Marking this PR as Ready to Review, I have verified that:

- [x] This PR fulfills the acceptance criteria detailed in the issue.
- [x] This PR matches the coding standards.
- [x] Related unit tests have been written, or updated to reflect the changes here.
- [x] All tests have passed.
- [x] I have filled out the "Testing" section with detailed instructions on how to test this PR
- [x] I have assigned this PR to myself
- [x] I have linked this PR to the issue it is intended to close.

## Before Merge, the Reviewer has verified that:

- [x] This PR fulfills the acceptance criteria detailed in the issue.
- [x] This PR matches the coding standards.
- [x] All unit tests have passed.
- [x] The code has been reviewed.
- [x] Any changes to the code has been appropriately covered in unit tests.