### PR TITLE
Issue/63 - Implement support for converting tags to strings, and vice-versa

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -157,12 +157,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Underpin-WP/underpin.git",
-                "reference": "a580dfbca12c90a86d3c777daa1bee0e682c0232"
+                "reference": "d35b697c100084d398230fb212b422a5f152bdca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Underpin-WP/underpin/zipball/a580dfbca12c90a86d3c777daa1bee0e682c0232",
-                "reference": "a580dfbca12c90a86d3c777daa1bee0e682c0232",
+                "url": "https://api.github.com/repos/Underpin-WP/underpin/zipball/d35b697c100084d398230fb212b422a5f152bdca",
+                "reference": "d35b697c100084d398230fb212b422a5f152bdca",
                 "shasum": ""
             },
             "require": {
@@ -194,7 +194,7 @@
                 "issues": "https://github.com/Underpin-WP/underpin/issues",
                 "source": "https://github.com/Underpin-WP/underpin/tree/3.0.1"
             },
-            "time": "2022-11-18T23:27:14+00:00"
+            "time": "2022-11-19T02:51:37+00:00"
         }
     ],
     "packages-dev": [

--- a/lib/Collections/Tag_Collection.php
+++ b/lib/Collections/Tag_Collection.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Adiungo\Core\Collections;
+
+use Adiungo\Core\Factories\Tag;
+use Underpin\Abstracts\Registries\Object_Registry;
+use Underpin\Exceptions\Operation_Failed;
+
+class Tag_Collection extends Object_Registry
+{
+    protected string $abstraction_class = Tag::class;
+
+    final public function __construct()
+    {
+    }
+
+    /**
+     * @throws Operation_Failed
+     */
+    public static function from_string(string $content): static
+    {
+        $result = new static();
+        preg_match_all('/#([\w]+)/', $content, $tags);
+
+        // Bail early if we couldn't find any tags.
+        if (!isset($tags[1])) {
+            return $result;
+        }
+
+        foreach ($tags[1] as $tag) {
+            $tag = Tag::from_string($tag);
+
+            if (!is_string($tag->get_id())) {
+                throw new Operation_Failed('Could not create tag from string', 500, 'error');
+            }
+
+            $result->add($tag->get_id(), $tag);
+        }
+
+        return $result;
+    }
+}

--- a/lib/Factories/Tag.php
+++ b/lib/Factories/Tag.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Adiungo\Core\Factories;
+
+
+use Adiungo\Core\Interfaces\Has_Name;
+use Adiungo\Core\Traits\With_Name;
+use Underpin\Exceptions\Operation_Failed;
+use Underpin\Helpers\String_Helper;
+use Underpin\Interfaces\Can_Convert_To_String;
+use Underpin\Interfaces\Identifiable_String;
+use Underpin\Traits\With_String_Identity;
+
+class Tag implements Identifiable_String, Has_Name, Can_Convert_To_String
+{
+    use With_String_Identity;
+    use With_Name;
+
+    final public function __construct()
+    {
+
+    }
+
+    /**
+     * Generates a tag object from a hashtag string.
+     *
+     * @param string $hash_tag
+     * @return static
+     * @throws Operation_Failed
+     */
+    public static function from_string(string $hash_tag): static
+    {
+        // Strip hashmark off the front, if it's there.
+        $tag = String_Helper::trim_leading($hash_tag, '#');
+
+        // If this happens to be camel case, break it into multiple words.
+        $name = preg_replace('/(?<=[A-Z])(?=[A-Z][a-z])|(?<=[a-z])(?=[A-Z])/', '$1 $2', $tag);
+
+        if (!$name) {
+            throw new Operation_Failed('Could not create tag from provided string', 500, 'error');
+        }
+
+        // If the name has underscores or dashes, replace them with spaces.
+        $name = ucwords(str_replace('-', ' ', str_replace('_', ' ', $name)));
+
+        // And ID is just a slugified version of this.
+        $id = strtolower(str_replace(' ', '-', $name));
+
+        // Set the name, processed to the best of our abilities.
+        return (new static())->set_id($id)->set_name($name);
+    }
+
+    /**
+     * Magic method for string conversion.
+     *
+     * @return string
+     */
+    public function __toString(): string
+    {
+        return $this->to_string();
+    }
+
+    /**
+     * Converts this tag into a hashtag.
+     *
+     * @return string
+     */
+    public function to_string(): string
+    {
+        return String_Helper::prepend(str_replace(' ', '', ucwords(strtolower($this->get_name()))), '#');
+    }
+}

--- a/tests/Unit/Collection/Tag_Collection_Test.php
+++ b/tests/Unit/Collection/Tag_Collection_Test.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Adiungo\Core\Tests\Unit\Collection;
+
+
+use Adiungo\Core\Collections\Tag_Collection;
+use Adiungo\Core\Factories\Tag;
+use Adiungo\Core\Tests\Test_Case;
+use Generator;
+use Underpin\Exceptions\Operation_Failed;
+
+class Tag_Collection_Test extends Test_Case
+{
+
+    /**
+     * @covers       \Adiungo\Core\Collections\Tag_Collection::from_string
+     *
+     * @param Tag_Collection $expected
+     * @param string $content
+     * @return void
+     * @throws Operation_Failed
+     * @dataProvider provider_can_create_from_string
+     */
+    public function test_can_create_from_string(Tag_Collection $expected, string $content): void
+    {
+        $this->assertEquals($expected, Tag_Collection::from_string($content));
+    }
+
+    /**
+     * @throws Operation_Failed
+     */
+    public function provider_can_create_from_string(): Generator
+    {
+        yield 'content' => [
+            (new Tag_Collection())
+                ->add('content', Tag::from_string('#content'))
+                ->add('project-adiungo', Tag::from_string('#ProjectAdiungo'))
+                ->add('hashtags', Tag::from_string('#hashtags')),
+            'This is a piece of #content about #ProjectAdiungo that should contain three #hashtags'
+        ];
+    }
+}

--- a/tests/Unit/Factories/Tag_Test.php
+++ b/tests/Unit/Factories/Tag_Test.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Adiungo\Core\Tests\Unit\Factories;
+
+
+use Adiungo\Core\Factories\Tag;
+use Adiungo\Core\Tests\Test_Case;
+use Generator;
+use Underpin\Exceptions\Operation_Failed;
+
+class Tag_Test extends Test_Case
+{
+
+    /**
+     * @covers       \Adiungo\Core\Factories\Tag::from_string
+     *
+     * @param Tag $expected
+     * @param string $tag
+     * @return void
+     * @dataProvider provider_can_get_from_string
+     * @throws Operation_Failed
+     */
+    public function test_can_get_from_string(Tag $expected, string $tag): void
+    {
+        $this->assertEquals($expected, Tag::from_string($tag));
+    }
+
+    /** @see test_can_get_from_string */
+    public function provider_can_get_from_string(): Generator
+    {
+        yield 'with camel case' => [(new Tag())->set_id('this-is-a-hashtag')->set_name('This Is A Hashtag'), '#ThisIsAHashtag'];
+        yield 'without camel case' => [(new Tag())->set_id('thishashtag')->set_name('Thishashtag'), '#Thishashtag'];
+        yield 'with dashes' => [(new Tag())->set_id('this-hashtag')->set_name('This Hashtag'), '#this-hashtag'];
+        yield 'with underscores' => [(new Tag())->set_id('this-hashtag')->set_name('This Hashtag'), '#this_hashtag'];
+        yield 'with numbers' => [(new Tag())->set_id('this-hashtag234')->set_name('This Hashtag234'), '#thisHashtag234'];
+    }
+
+    /**
+     * @param string $expected
+     * @param Tag $tag
+     * @return void
+     * @dataProvider provider_can_convert_to_string
+     */
+    public function test_can_convert_to_string(string $expected, Tag $tag): void
+    {
+        $this->assertEquals($expected, $tag->to_string());
+        $this->assertEquals($expected, (string)$tag);
+    }
+
+    /** @see test_can_convert_to_string */
+    public function provider_can_convert_to_string(): Generator
+    {
+        yield 'Happy Path' => ['#ThisIsAHashtag', (new Tag())->set_name('This Is A Hashtag')];
+        yield 'Mixed Case' => ['#ThisIsAHashtag', (new Tag())->set_name('ThIs IS a HashTAG')];
+        yield 'Lower Case' => ['#ThisIsAHashtag', (new Tag())->set_name('this is a hashtag')];
+        yield 'without camel case' => ['#Thishashtag', (new Tag())->set_name('Thishashtag')];
+        yield 'with numbers' => ['#ThisHashtag234', (new Tag())->set_name('This Hashtag234')];
+    }
+
+}


### PR DESCRIPTION
## Summary

Resolves #63 

This PR introduces methods needed to be able to convert a string containing hashtags into a collection of fully formed, parsed tags.

## Details

This accomplishes the goal of converting tags to and from hashtag strings by implementing the `Tag_Collection` and `Tag` classes, along with static methods to handle conversions.

`Tag::to_string()` will convert a `Tag` object into a hashtag. This can also be typecasted like `(string) $tag` where `$tag` is an instance of `Tag`.

`Tag::from_string()` will convert a `#hashTag` into a tag whose name is `Hash Tag` and the ID is `hash-tag`. It will try to parse the name to the best of it's abilities, as well as the slug.

`Tag_Collection::from_string()` will convert a piece of content into a collection of tags. So if you have a paragraph of text with a series of hashtags embedded, this will detect those tags, and extract them.

## Before Marking this PR as Ready to Review, I have verified that:

- [x] This PR fulfills the acceptance criteria detailed in the issue.
- [x] This PR matches the coding standards.
- [x] Related unit tests have been written, or updated to reflect the changes here.
- [x] All tests have passed.
- [x] I have filled out the "Testing" section with detailed instructions on how to test this PR
- [x] I have assigned this PR to myself
- [x] I have linked this PR to the issue it is intended to close.

## Before Merge, the Reviewer has verified that:

- [x] This PR fulfills the acceptance criteria detailed in the issue.
- [x] This PR matches the coding standards.
- [x] All unit tests have passed.
- [x] The code has been reviewed.
- [x] Any changes to the code has been appropriately covered in unit tests.