### PR TITLE
Issue/97 - Updates Queue_Index_Event to no longer require a strategy builder instance

### DIFF
--- a/lib/Events/Queue_Index_Event.php
+++ b/lib/Events/Queue_Index_Event.php
@@ -3,8 +3,8 @@
 namespace Adiungo\Core\Events;
 
 
-use Adiungo\Core\Abstracts\Index_Strategy_Builder;
 use Adiungo\Core\Events\Providers\Index_Strategy_Provider;
+use Adiungo\Core\Interfaces\Has_Index_Strategy;
 use Underpin\Exceptions\Operation_Failed;
 use Underpin\Exceptions\Unknown_Registry_Item;
 use Underpin\Interfaces\Singleton;
@@ -16,43 +16,40 @@ class Queue_Index_Event implements Singleton
     use With_Instance;
     use With_Broadcaster;
 
-    protected function get_broadcaster_key(Index_Strategy_Builder $builder): string
-    {
-        return $builder->get_index_strategy()->get_data_source()::class . '__' . $builder->get_model();
-    }
-
     /**
      * Attach a callback to the specified index event.
      *
-     * @param Index_Strategy_Builder $builder
+     * @param class-string<Has_Index_Strategy> $builder
      * @param callable $callback
      * @return void
      * @throws Operation_Failed
      * @throws Unknown_Registry_Item
      */
-    public function attach(Index_Strategy_Builder $builder, callable $callback): void
+    public function attach(string $builder, callable $callback): void
     {
-        $this->get_broadcaster()->attach($this->get_broadcaster_key($builder), $callback);
+        $this->get_broadcaster()->attach($builder, $callback);
     }
 
     /**
      * Detach a callback from the specified index event.
+     * @param class-string<Has_Index_Strategy> $builder
+     * @param callable $callback
      *
      * @throws Operation_Failed
      */
-    public function detach(Index_Strategy_Builder $builder, callable $callback): void
+    public function detach(string $builder, callable $callback): void
     {
-        $this->get_broadcaster()->detach($this->get_broadcaster_key($builder), $callback);
+        $this->get_broadcaster()->detach($builder, $callback);
     }
 
     /**
      * Broadcasts this event.
      *
-     * @param Index_Strategy_Builder $builder
+     * @param Has_Index_Strategy $builder
      * @return void
      */
-    public function broadcast(Index_Strategy_Builder $builder): void
+    public function broadcast(Has_Index_Strategy $builder): void
     {
-        $this->get_broadcaster()->broadcast($this->get_broadcaster_key($builder), new Index_Strategy_Provider($builder->get_index_strategy()));
+        $this->get_broadcaster()->broadcast($builder::class, new Index_Strategy_Provider($builder->get_index_strategy()));
     }
 }

--- a/tests/Unit/Events/Queue_Index_Event_Test.php
+++ b/tests/Unit/Events/Queue_Index_Event_Test.php
@@ -3,39 +3,20 @@
 namespace Adiungo\Core\Tests\Unit\Events;
 
 
-use Adiungo\Core\Abstracts\Index_Strategy_Builder;
 use Adiungo\Core\Events\Providers\Index_Strategy_Provider;
 use Adiungo\Core\Events\Queue_Index_Event;
 use Adiungo\Core\Factories\Index_Strategy;
-use Adiungo\Core\Interfaces\Data_Source;
+use Adiungo\Core\Interfaces\Has_Index_Strategy;
+use Adiungo\Core\Traits\With_Index_Strategy;
 use Adiungo\Tests\Test_Case;
 use Adiungo\Tests\Traits\With_Inaccessible_Methods;
 use Mockery;
-use ReflectionException;
 use Underpin\Exceptions\Operation_Failed;
 use Underpin\Exceptions\Unknown_Registry_Item;
 
 class Queue_Index_Event_Test extends Test_Case
 {
     use With_Inaccessible_Methods;
-
-    /**
-     * @covers \Adiungo\Core\Events\Queue_Index_Event::get_broadcaster_key
-     *
-     * @return void
-     * @throws ReflectionException
-     */
-    public function test_can_get_broadcaster_key(): void
-    {
-        $instance = new Queue_Index_Event();
-        $index_strategy_builder = Mockery::mock(Index_Strategy_Builder::class);
-        $data_source = Mockery::namedMock('Foo', Data_Source::class);
-
-        $index_strategy_builder->allows('get_model')->andReturn('Bar');
-        $index_strategy_builder->allows('get_index_strategy->get_data_source')->andReturn($data_source);
-
-        $this->assertEquals('Foo__Bar', $this->call_inaccessible_method($instance, 'get_broadcaster_key', $index_strategy_builder));
-    }
 
     /**
      * @covers \Adiungo\Core\Events\Queue_Index_Event::attach
@@ -48,13 +29,14 @@ class Queue_Index_Event_Test extends Test_Case
     {
         $instance = Mockery::mock(Queue_Index_Event::class);
         $instance->shouldAllowMockingProtectedMethods()->makePartial();
-        $index_strategy_builder = Mockery::mock(Index_Strategy_Builder::class);
+
+        /** @var Mockery\MockInterface&Has_Index_Strategy $index_strategy_builder */
+        $index_strategy_builder = Mockery::namedMock('Builder', $this->create_builder()::class);
         $callback = fn() => '';
 
-        $instance->allows('get_broadcaster_key')->with($index_strategy_builder)->andReturn('foo');
-        $instance->expects('get_broadcaster->attach')->with('foo', $callback);
+        $instance->expects('get_broadcaster->attach')->with('Builder', $callback);
 
-        $instance->attach($index_strategy_builder, $callback);
+        $instance->attach($index_strategy_builder::class, $callback);
     }
 
     /**
@@ -67,13 +49,14 @@ class Queue_Index_Event_Test extends Test_Case
     {
         $instance = Mockery::mock(Queue_Index_Event::class);
         $instance->shouldAllowMockingProtectedMethods()->makePartial();
-        $index_strategy_builder = Mockery::mock(Index_Strategy_Builder::class);
+
+        /** @var Mockery\MockInterface&Has_Index_Strategy $index_strategy_builder */
+        $index_strategy_builder = Mockery::namedMock('Builder', $this->create_builder()::class);
         $callback = fn() => '';
 
-        $instance->allows('get_broadcaster_key')->with($index_strategy_builder)->andReturn('foo');
-        $instance->expects('get_broadcaster->detach')->with('foo', $callback);
+        $instance->expects('get_broadcaster->detach')->with('Builder', $callback);
 
-        $instance->detach($index_strategy_builder, $callback);
+        $instance->detach($index_strategy_builder::class, $callback);
     }
 
     /**
@@ -88,17 +71,27 @@ class Queue_Index_Event_Test extends Test_Case
 
         $strategy = Mockery::mock(Index_Strategy::class);
 
-        $index_strategy_builder = Mockery::mock(Index_Strategy_Builder::class);
+        /** @var Mockery\MockInterface&Has_Index_Strategy $index_strategy_builder */
+        $index_strategy_builder = Mockery::namedMock('Builder', $this->create_builder()::class);
         $index_strategy_builder->allows('get_index_strategy')->andReturn($strategy);
 
-        $instance->allows('get_broadcaster_key')->with($index_strategy_builder)->andReturn('foo');
-
         $instance->expects('get_broadcaster->broadcast')->withArgs(function ($key, $strategy_test) use ($strategy) {
-            return $key === 'foo' && $strategy_test instanceof Index_Strategy_Provider && $strategy_test->get_index_strategy() === $strategy;
+            return $key === 'Builder' && $strategy_test instanceof Index_Strategy_Provider && $strategy_test->get_index_strategy() === $strategy;
         });
 
 
         $instance->broadcast($index_strategy_builder);
     }
 
+    /**
+     * Creates a builder stub.
+     *
+     * @return Has_Index_Strategy
+     */
+    private function create_builder(): Has_Index_Strategy
+    {
+        return new class implements Has_Index_Strategy {
+            use With_Index_Strategy;
+        };
+    }
 }


### PR DESCRIPTION
## Summary

Resolves #97

This PR makes `Queue_Index_Event` no longer depend on the `Index_Strategy_Bui

## Testing

<!-- Add steps to test this PR here. Remove the "Testing" Heading if there are no testing steps to make. -->

## Before Marking this PR as Ready to Review, I have verified that:

- [x] This PR fulfills the acceptance criteria detailed in the issue.
- [x] This PR matches the coding standards.
- [x] Related unit tests have been written, or updated to reflect the changes here.
- [x] All tests have passed.
- [x] I have filled out the "Testing" section with detailed instructions on how to test this PR
- [x] I have assigned this PR to myself
- [x] I have linked this PR to the issue it is intended to close.

## Before Merge, the Reviewer has verified that:

- [x] This PR fulfills the acceptance criteria detailed in the issue.
- [x] This PR matches the coding standards.
- [x] All unit tests have passed.
- [x] The code has been reviewed.
- [x] Any changes to the code has been appropriately covered in unit tests.