### PR TITLE
Extracts Data Source adapter functionality from CSV class

### DIFF
--- a/lib/Factories/Adapters/Data_Source_Adapter.php
+++ b/lib/Factories/Adapters/Data_Source_Adapter.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Adiungo\Core\Factories\Adapters;
+
+
+use Adiungo\Core\Abstracts\Content_Model;
+use Adiungo\Core\Interfaces\Has_Content_Model_Instance;
+use Adiungo\Core\Traits\With_Content_Model_Instance;
+use TypeError;
+use Underpin\Enums\Types;
+use Underpin\Exceptions\Operation_Failed;
+use Underpin\Exceptions\Unknown_Registry_Item;
+use Underpin\Factories\Registry;
+use Underpin\Helpers\Array_Helper;
+use Underpin\Traits\With_Object_Cache;
+
+class Data_Source_Adapter implements Has_Content_Model_Instance
+{
+    use With_Object_Cache;
+    use With_Content_Model_Instance;
+
+    /**
+     * Attempts to map a column to the specified model setter.
+     *
+     * @param string $column The CSV column name
+     * @param string $model_setter The setter function that should be called on the model.
+     * @param Types $type The PHP type that the column should be set to before setting on the model.
+     * @return static
+     * @throws Operation_Failed
+     */
+    public function map_field(string $column, string $model_setter, Types $type): static
+    {
+        try {
+            $this->get_mappings()->add($column, ['setter' => $model_setter, 'type' => $type]);
+        } catch (Operation_Failed $e) {
+            $model = $this->get_content_model_instance();
+            throw new Operation_Failed("Column mapping failed - The $model_setter method cannot be found on the $model model.");
+        }
+
+        return $this;
+    }
+
+    /**
+     * Loads the mapping registry.
+     *
+     * @return Registry
+     */
+    public function get_mappings(): Registry
+    {
+        return $this->load_from_cache('mappings', fn() => new Registry(fn($key, $value) => $this->mapping_is_valid($value['setter'], $value['type'])));
+    }
+
+    /**
+     * Returns true if the provided mapping is valid
+     *
+     * @param string $setter The setter method to call on the model
+     * @param Types $type The type to set.
+     * @return bool
+     */
+    protected function mapping_is_valid(string $setter, Types $type): bool
+    {
+        return method_exists($this->get_content_model_instance(), $setter) && $type instanceof Types;
+    }
+
+    /**
+     * Converts a set of raw data into the model, using the mappings set in this class.
+     *
+     * @param string[] $raw_model
+     * @return Content_Model
+     * @throws Operation_Failed
+     */
+    public function convert_to_model(array $raw_model): Content_Model
+    {
+        $model = $this->get_content_model_instance();
+
+        /** @var Content_Model $model */
+        $model = new $model();
+
+        try {
+            Array_Helper::each($raw_model, fn(mixed $item, string $key) => $this->set_mapped_property($key, $item, $model));
+        } catch (TypeError $exception) {
+            throw new Operation_Failed("Could not adapt CSV to the model.", previous: $exception);
+        } catch (Unknown_Registry_Item $exception) {
+            throw new Operation_Failed("Could not adapt CSV to the model because the mapped property was not set.", previous: $exception);
+        }
+
+        return $model;
+    }
+
+    /**
+     * @param string $key
+     * @param mixed $item
+     * @param Content_Model $model
+     * @return void
+     * @throws Unknown_Registry_Item
+     */
+    protected function set_mapped_property(string $key, mixed $item, Content_Model $model): void
+    {
+        /** @var array{type:Types, setter:string} $mapping */
+        $mapping = $this->get_mappings()->get($key);
+
+        settype($item, $mapping['type']->value);
+
+        $model->{$mapping['setter']}($item);
+    }
+}

--- a/lib/Factories/Data_Sources/CSV.php
+++ b/lib/Factories/Data_Sources/CSV.php
@@ -5,28 +5,24 @@ namespace Adiungo\Core\Factories\Data_Sources;
 use Adiungo\Core\Abstracts\Content_Model;
 use Adiungo\Core\Collections\Content_Model_Collection;
 use Adiungo\Core\Interfaces\Data_Source;
-use Adiungo\Core\Interfaces\Has_Content_Model_Instance;
+use Adiungo\Core\Interfaces\Has_Data_Source_Adapter;
 use Adiungo\Core\Interfaces\Has_Limit;
 use Adiungo\Core\Interfaces\Has_Offset;
-use Adiungo\Core\Traits\With_Content_Model_Instance;
+use Adiungo\Core\Traits\With_Data_Source_Adapter;
 use Adiungo\Core\Traits\With_Limit;
 use Adiungo\Core\Traits\With_Offset;
 use ParseCsv\Csv as CSV_Lib;
-use TypeError;
-use Underpin\Enums\Types;
 use Underpin\Exceptions\Item_Not_Found;
 use Underpin\Exceptions\Operation_Failed;
-use Underpin\Exceptions\Unknown_Registry_Item;
-use Underpin\Factories\Registry;
 use Underpin\Helpers\Array_Helper;
 use Underpin\Traits\With_Object_Cache;
 
-class CSV implements Data_Source, Has_Content_Model_Instance, Has_Offset, Has_Limit
+class CSV implements Data_Source, Has_Offset, Has_Limit, Has_Data_Source_Adapter
 {
-    use With_Content_Model_Instance;
     use With_Offset;
     use With_Limit;
     use With_Object_Cache;
+    use With_Data_Source_Adapter;
 
     /**
      * Source CSV String
@@ -34,49 +30,6 @@ class CSV implements Data_Source, Has_Content_Model_Instance, Has_Offset, Has_Li
      * @var string
      */
     protected string $csv;
-
-    /**
-     * Attempts to map a column to the specified model setter.
-     *
-     * @param string $column The CSV column name
-     * @param string $model_setter The setter function that should be called on the model.
-     * @param Types $type The PHP type that the column should be set to before setting on the model.
-     * @return static
-     * @throws Operation_Failed
-     */
-    public function map_column(string $column, string $model_setter, Types $type): static
-    {
-        try {
-            $this->get_mappings()->add($column, ['setter' => $model_setter, 'type' => $type]);
-        } catch (Operation_Failed $e) {
-            $model = $this->get_content_model_instance();
-            throw new Operation_Failed("Column mapping failed - The $model_setter method cannot be found on the $model model.");
-        }
-
-        return $this;
-    }
-
-    /**
-     * Loads the mapping registry.
-     *
-     * @return Registry
-     */
-    protected function get_mappings(): Registry
-    {
-        return $this->load_from_cache('mappings', fn() => new Registry(fn($key, $value) => $this->mapping_is_valid($value['setter'], $value['type'])));
-    }
-
-    /**
-     * Returns true if the provided mapping is valid
-     *
-     * @param string $setter The setter method to call on the model
-     * @param Types $type The type to set.
-     * @return bool
-     */
-    protected function mapping_is_valid(string $setter, Types $type): bool
-    {
-        return method_exists($this->get_content_model_instance(), $setter) && $type instanceof Types;
-    }
 
     /**
      * Sets the raw CSV string to use in this data source.
@@ -101,7 +54,7 @@ class CSV implements Data_Source, Has_Content_Model_Instance, Has_Offset, Has_Li
         $csv = $this->get_csv_instance();
         $csv->parse($this->csv, $this->get_offset(), $this->get_limit());
 
-        return (new Content_Model_Collection())->seed(Array_Helper::map($csv->data, fn(array $datum) => $this->convert_to_model($datum)));
+        return (new Content_Model_Collection())->seed(Array_Helper::map($csv->data, fn(array $datum) => $this->get_data_source_adapter()->convert_to_model($datum)));
     }
 
     /**
@@ -115,53 +68,17 @@ class CSV implements Data_Source, Has_Content_Model_Instance, Has_Offset, Has_Li
     }
 
     /**
-     * Converts a set of raw data into the model, using the mappings set in this class.
-     *
-     * @param string[] $raw_model
-     * @return Content_Model
-     * @throws Operation_Failed
+     * @inheritDoc
      */
-    protected function convert_to_model(array $raw_model): Content_Model
-    {
-        $model = $this->get_content_model_instance();
-
-        /** @var Content_Model $model */
-        $model = new $model();
-
-        try {
-            Array_Helper::each($raw_model, fn(mixed $item, string $key) => $this->set_mapped_property($key, $item, $model));
-        } catch (TypeError $exception) {
-            throw new Operation_Failed("Could not adapt CSV to the model.", previous: $exception);
-        } catch (Unknown_Registry_Item $exception) {
-            throw new Operation_Failed("Could not adapt CSV to the model because the mapped property was not set.", previous: $exception);
-        }
-
-        return $model;
-    }
-
-    /**
-     * @param string $key
-     * @param mixed $item
-     * @param Content_Model $model
-     * @return void
-     * @throws Unknown_Registry_Item
-     */
-    protected function set_mapped_property(string $key, mixed $item, Content_Model $model): void
-    {
-        /** @var array{type:Types, setter:string} $mapping */
-        $mapping = $this->get_mappings()->get($key);
-
-        settype($item, $mapping['type']->value);
-
-        $model->{$mapping['setter']}($item);
-    }
-
     public function has_more(): bool
     {
         $this->get_csv_instance()->loadDataString($this->csv);
         return $this->get_csv_instance()->getTotalDataRowCount() > $this->get_offset();
     }
 
+    /**
+     * @inheritDoc
+     */
     public function get_next(): Data_Source
     {
         return (clone $this)->set_offset($this->get_offset() + $this->get_limit());
@@ -177,7 +94,7 @@ class CSV implements Data_Source, Has_Content_Model_Instance, Has_Offset, Has_Li
      */
     public function get_item(int|string $id): Content_Model
     {
-        $column = array_keys($this->get_mappings()->filter(fn(array $item) => $item['setter'] === 'set_id')->to_array());
+        $column = array_keys($this->get_data_source_adapter()->get_mappings()->filter(fn(array $item) => $item['setter'] === 'set_id')->to_array());
         if (empty($column)) {
             throw new Item_Not_Found("Could not find ID column in adapter. Did you remember to set the column mapping with get_id?");
         }
@@ -189,6 +106,6 @@ class CSV implements Data_Source, Has_Content_Model_Instance, Has_Offset, Has_Li
             throw new Item_Not_Found("No item with that ID exists in this file.");
         }
 
-        return $this->convert_to_model($csv->data[0]);
+        return $this->get_data_source_adapter()->convert_to_model($csv->data[0]);
     }
 }

--- a/lib/Interfaces/Has_Data_Source_Adapter.php
+++ b/lib/Interfaces/Has_Data_Source_Adapter.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Adiungo\Core\Interfaces;
+
+
+namespace Adiungo\Core\Interfaces;
+
+use Adiungo\Core\Factories\Adapters\Data_Source_Adapter;
+
+interface Has_Data_Source_Adapter
+{
+
+    /**
+     * Gets the data source adapter.
+     *
+     * @return Data_Source_Adapter
+     */
+    public function get_data_source_adapter(): Data_Source_Adapter;
+
+    /**
+     * Sets the data source adapter
+     *
+     * @param Data_Source_Adapter $data_source_adapter
+     * @return $this
+     */
+    public function set_data_source_adapter(Data_Source_Adapter $data_source_adapter): static;
+
+}

--- a/lib/Traits/With_Data_Source_Adapter.php
+++ b/lib/Traits/With_Data_Source_Adapter.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Adiungo\Core\Traits;
+
+
+use Adiungo\Core\Factories\Adapters\Data_Source_Adapter;
+
+trait With_Data_Source_Adapter
+{
+
+    protected Data_Source_Adapter $data_source_adapter;
+
+    /**
+     * Gets the data source adapter.
+     *
+     * @return Data_Source_Adapter
+     */
+    public function get_data_source_adapter(): Data_Source_Adapter
+    {
+        return $this->data_source_adapter;
+    }
+
+    /**
+     * Sets the data source adapter
+     *
+     * @param Data_Source_Adapter $data_source_adapter
+     * @return $this
+     */
+    public function set_data_source_adapter(Data_Source_Adapter $data_source_adapter): static
+    {
+        $this->data_source_adapter = $data_source_adapter;
+
+        return $this;
+    }
+
+}

--- a/tests/Integration/CSV_Data_Source_Test.php
+++ b/tests/Integration/CSV_Data_Source_Test.php
@@ -3,6 +3,7 @@
 namespace Adiungo\Core\Tests\Integration;
 
 use Adiungo\Core\Collections\Content_Model_Collection;
+use Adiungo\Core\Factories\Adapters\Data_Source_Adapter;
 use Adiungo\Core\Factories\Data_Sources\CSV;
 use Adiungo\Core\Tests\Integration\Mocks\Test_Model;
 use Adiungo\Tests\Test_Case;
@@ -19,11 +20,14 @@ class CSV_Data_Source_Test extends Test_Case
      */
     public function test_can_get_item(): void
     {
-        $item = (new CSV())
+        $adapter = (new Data_Source_Adapter())
             ->set_content_model_instance(Test_Model::class)
-            ->map_column('content', 'set_content', Types::String)
-            ->map_column('name', 'set_name', Types::String)
-            ->map_column('id', 'set_id', Types::Integer)
+            ->map_field('content', 'set_content', Types::String)
+            ->map_field('name', 'set_name', Types::String)
+            ->map_field('id', 'set_id', Types::Integer);
+
+        $item = (new CSV())
+            ->set_data_source_adapter($adapter)
             ->set_csv("id,content,name\r1,\"the content\",alex\r2,\"more content\",stephen")
             ->get_item(2);
 
@@ -42,11 +46,14 @@ class CSV_Data_Source_Test extends Test_Case
      */
     public function test_can_get_data(): void
     {
-        $item = (new CSV())
+        $adapter = (new Data_Source_Adapter())
             ->set_content_model_instance(Test_Model::class)
-            ->map_column('content', 'set_content', Types::String)
-            ->map_column('name', 'set_name', Types::String)
-            ->map_column('id', 'set_id', Types::Integer)
+            ->map_field('content', 'set_content', Types::String)
+            ->map_field('name', 'set_name', Types::String)
+            ->map_field('id', 'set_id', Types::Integer);
+
+        $item = (new CSV())
+            ->set_data_source_adapter($adapter)
             ->set_offset(2)
             ->set_limit(2)
             ->set_csv("id,content,name\r1,\"the content\",alex\r2,\"more content\",stephen\r3,\"another content\",kate\r4,\"even more content\",kara")
@@ -72,11 +79,14 @@ class CSV_Data_Source_Test extends Test_Case
      */
     public function test_can_get_next(): void
     {
-        $item = (new CSV())
+        $adapter = (new Data_Source_Adapter())
             ->set_content_model_instance(Test_Model::class)
-            ->map_column('content', 'set_content', Types::String)
-            ->map_column('name', 'set_name', Types::String)
-            ->map_column('id', 'set_id', Types::Integer)
+            ->map_field('content', 'set_content', Types::String)
+            ->map_field('name', 'set_name', Types::String)
+            ->map_field('id', 'set_id', Types::Integer);
+
+        $item = (new CSV())
+            ->set_data_source_adapter($adapter)
             ->set_offset(1)
             ->set_limit(2)
             ->set_csv("id,content,name\r1,\"the content\",alex\r2,\"more content\",stephen\r3,\"another content\",kate\r4,\"even more content\",kara")
@@ -104,11 +114,14 @@ class CSV_Data_Source_Test extends Test_Case
      */
     public function test_can_loop(): void
     {
-        $item = (new CSV())
+        $adapter = (new Data_Source_Adapter())
             ->set_content_model_instance(Test_Model::class)
-            ->map_column('content', 'set_content', Types::String)
-            ->map_column('name', 'set_name', Types::String)
-            ->map_column('id', 'set_id', Types::Integer)
+            ->map_field('content', 'set_content', Types::String)
+            ->map_field('name', 'set_name', Types::String)
+            ->map_field('id', 'set_id', Types::Integer);
+
+        $item = (new CSV())
+            ->set_data_source_adapter($adapter)
             ->set_offset(1)
             ->set_limit(1)
             ->set_csv("id,content,name\r1,\"the content\",alex\r2,\"more content\",stephen\r3,\"another content\",kate\r4,\"even more content\",kara");

--- a/tests/Unit/Factories/Adapters/Data_Source_Adapter_Test.php
+++ b/tests/Unit/Factories/Adapters/Data_Source_Adapter_Test.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace Adiungo\Core\Tests\Unit\Factories\Adapters;
+
+
+use Adiungo\Core\Abstracts\Content_Model;
+use Adiungo\Core\Factories\Adapters\Data_Source_Adapter;
+use Adiungo\Tests\Test_Case;
+use Adiungo\Tests\Traits\With_Inaccessible_Methods;
+use Generator;
+use Mockery;
+use ReflectionException;
+use Underpin\Enums\Types;
+use Underpin\Exceptions\Operation_Failed;
+use Underpin\Factories\Registry;
+
+class Data_Source_Adapter_Test extends Test_Case
+{
+    use With_Inaccessible_Methods;
+
+    /**
+     * @covers \Adiungo\Core\Factories\Data_Sources\CSV::convert_to_model
+     *
+     * @throws ReflectionException
+     */
+    public function test_can_convert_to_model(): void
+    {
+        $instance = Mockery::mock(Data_Source_Adapter::class)->shouldAllowMockingProtectedMethods()->makePartial();
+
+        Mockery::namedMock('Test_Mock', Content_Model::class);
+
+        $items = ['a' => 'set_a', 'b' => 'set_b', 'c' => 'set_c', 'd' => 'set_d'];
+
+        $instance->expects('set_mapped_property')->times(count($items))->withArgs(function ($key, $item, $model) use ($items) {
+            if ("Test_Mock" instanceof $model) {
+                return false;
+            }
+
+            return $items[$key] === $item;
+        });
+        $instance->allows('get_content_model_instance')->andReturn('Test_Mock');
+
+        $this->call_inaccessible_method($instance, 'convert_to_model', $items);
+    }
+
+    /**
+     * @covers       \Adiungo\Core\Factories\Data_Sources\CSV::set_mapped_property()
+     *
+     * @param mixed $expected
+     * @param mixed $value
+     * @param array{type:Types, setter:string} $mapping
+     * @throws ReflectionException
+     * @dataProvider provider_set_mapped_property
+     */
+    public function test_can_set_mapped_property(mixed $expected, mixed $value, array $mapping): void
+    {
+        $source = Mockery::mock(Data_Source_Adapter::class)->shouldAllowMockingProtectedMethods()->makePartial();
+        $source->allows('get_mappings->get')->with('key')->andReturn($mapping);
+
+        $model = Mockery::mock(Content_Model::class);
+        $model->expects($mapping['setter'])->with($expected)->andReturn($model);
+
+        $this->call_inaccessible_method($source, 'set_mapped_property', 'key', $value, $model);
+    }
+
+    public function provider_set_mapped_property(): Generator
+    {
+        yield 'it converts types' => [6, '6', ['setter' => 'set_int', 'type' => Types::Integer]];
+        yield 'it sets values' => ['alex', 'alex', ['setter' => 'set_name', 'type' => Types::String]];
+    }
+
+    /**
+     * @covers       \Adiungo\Core\Factories\Data_Sources\CSV::mapping_is_valid
+     *
+     * @throws ReflectionException
+     * @dataProvider provider_mapping_is_valid
+     */
+    public function test_mapping_is_valid(bool $expected, string $setter): void
+    {
+        $mock = new class () extends Content_Model {
+            public function get_id(): string|int|null
+            {
+                return 123;
+            }
+
+            public function set_test_value(): void
+            {
+                return;
+            }
+        };
+
+        $instance = Mockery::mock(Data_Source_Adapter::class);
+        $instance->allows('get_content_model_instance')->andReturn($mock::class);
+
+        $this->assertSame($expected, $this->call_inaccessible_method($instance, 'mapping_is_valid', $setter, Types::String));
+    }
+
+    /**
+     * @covers \Adiungo\Core\Factories\Data_Sources\CSV::get_mappings
+     * @throws ReflectionException
+     */
+    public function test_can_get_mappings(): void
+    {
+        $source = new Data_Source_Adapter();
+        $item = $this->call_inaccessible_method($source, 'get_mappings');
+        $item_again = $this->call_inaccessible_method($source, 'get_mappings');
+
+        $this->assertSame($item, $item_again);
+        $this->assertInstanceOf(Registry::class, $item);
+    }
+
+    /**
+     * @covers \Adiungo\Core\Factories\Data_Sources\CSV::map_field
+     * @return void
+     * @throws Operation_Failed
+     */
+    public function test_can_map_field_catches_thrown_exceptions(): void
+    {
+        $instance = Mockery::mock(Data_Source_Adapter::class)->makePartial()->shouldAllowMockingProtectedMethods();
+        $column = 'foo';
+        $instance->allows('get_content_model_instance')->andReturn('Mocked_Model');
+        $setter = 'bar';
+        $type = Types::String;
+        $instance->expects('get_mappings->add')->with($column, ['setter' => $setter, 'type' => $type])->andThrow(Operation_Failed::class);
+
+        $this->expectException(Operation_Failed::class);
+        $this->expectExceptionMessage("Column mapping failed - The $setter method cannot be found on the Mocked_Model model.");
+
+        $instance->map_field($column, $setter, $type);
+    }
+
+    /**
+     * @covers \Adiungo\Core\Factories\Data_Sources\CSV::map_field
+     * @return void
+     * @throws Operation_Failed
+     */
+    public function test_can_map_field(): void
+    {
+        $instance = Mockery::mock(Data_Source_Adapter::class)->makePartial()->shouldAllowMockingProtectedMethods();
+        $column = 'foo';
+        $setter = 'bar';
+        $type = Types::String;
+        $instance->expects('get_mappings->add')->with($column, ['setter' => $setter, 'type' => $type]);
+
+        $this->assertSame($instance, $instance->map_field($column, $setter, $type));
+    }
+
+    /** @see test_mapping_is_valid */
+    protected function provider_mapping_is_valid(): Generator
+    {
+        yield 'valid setter returns true' => [true, 'set_test_value'];
+        yield 'invalid setter returns false' => [false, 'invalid'];
+    }
+
+}

--- a/tests/Unit/Factories/Data_Sources/CSV_Test.php
+++ b/tests/Unit/Factories/Data_Sources/CSV_Test.php
@@ -2,114 +2,17 @@
 
 namespace Adiungo\Core\Tests\Unit\Factories\Data_Sources;
 
-use Adiungo\Core\Abstracts\Content_Model;
 use Adiungo\Core\Factories\Data_Sources\CSV;
 use Adiungo\Tests\Test_Case;
 use Adiungo\Tests\Traits\With_Inaccessible_Methods;
 use Adiungo\Tests\Traits\With_Inaccessible_Properties;
-use Generator;
-use Mockery;
 use ParseCsv\Csv as CSV_Lib;
 use ReflectionException;
-use Underpin\Enums\Types;
-use Underpin\Exceptions\Operation_Failed;
-use Underpin\Factories\Registry;
 
 class CSV_Test extends Test_Case
 {
     use With_Inaccessible_Properties;
     use With_Inaccessible_Methods;
-
-    /**
-     * @covers \Adiungo\Core\Factories\Data_Sources\CSV::convert_to_model
-     *
-     * @throws ReflectionException
-     */
-    public function test_can_convert_to_model(): void
-    {
-        $instance = Mockery::mock(CSV::class)->shouldAllowMockingProtectedMethods()->makePartial();
-
-        Mockery::namedMock('Test_Mock', Content_Model::class);
-
-        $items = ['a' => 'set_a', 'b' => 'set_b', 'c' => 'set_c', 'd' => 'set_d'];
-
-        $instance->expects('set_mapped_property')->times(count($items))->withArgs(function ($key, $item, $model) use ($items) {
-            if ("Test_Mock" instanceof $model) {
-                return false;
-            }
-
-            return $items[$key] === $item;
-        });
-        $instance->allows('get_content_model_instance')->andReturn('Test_Mock');
-
-        $this->call_inaccessible_method($instance, 'convert_to_model', $items);
-    }
-
-    /**
-     * @covers       \Adiungo\Core\Factories\Data_Sources\CSV::set_mapped_property()
-     *
-     * @param mixed $expected
-     * @param mixed $value
-     * @param array{type:Types, setter:string} $mapping
-     * @throws ReflectionException
-     * @dataProvider provider_set_mapped_property
-     */
-    public function test_can_set_mapped_property(mixed $expected, mixed $value, array $mapping): void
-    {
-        $source = Mockery::mock(CSV::class)->shouldAllowMockingProtectedMethods()->makePartial();
-        $source->allows('get_mappings->get')->with('key')->andReturn($mapping);
-
-        $model = Mockery::mock(Content_Model::class);
-        $model->expects($mapping['setter'])->with($expected)->andReturn($model);
-
-        $this->call_inaccessible_method($source, 'set_mapped_property', 'key', $value, $model);
-    }
-
-    public function provider_set_mapped_property(): Generator
-    {
-        yield 'it converts types' => [6, '6', ['setter' => 'set_int', 'type' => Types::Integer]];
-        yield 'it sets values' => ['alex', 'alex', ['setter' => 'set_name', 'type' => Types::String]];
-    }
-
-    /**
-     * @covers       \Adiungo\Core\Factories\Data_Sources\CSV::mapping_is_valid
-     *
-     * @throws ReflectionException
-     * @dataProvider provider_mapping_is_valid
-     */
-    public function test_mapping_is_valid(bool $expected, string $setter): void
-    {
-        $mock = new class () extends Content_Model {
-            public function get_id(): string|int|null
-            {
-                return 123;
-            }
-
-            public function set_test_value(): void
-            {
-                return;
-            }
-        };
-
-        $instance = Mockery::mock(CSV::class);
-        $instance->allows('get_content_model_instance')->andReturn($mock::class);
-
-        $this->assertSame($expected, $this->call_inaccessible_method($instance, 'mapping_is_valid', $setter, Types::String));
-    }
-
-    /**
-     * @covers \Adiungo\Core\Factories\Data_Sources\CSV::get_mappings
-     * @throws ReflectionException
-     */
-    public function test_can_get_mappings(): void
-    {
-        $source = new CSV();
-        $item = $this->call_inaccessible_method($source, 'get_mappings');
-        $item_again = $this->call_inaccessible_method($source, 'get_mappings');
-
-        $this->assertSame($item, $item_again);
-        $this->assertInstanceOf(Registry::class, $item);
-    }
 
     /**
      * @covers \Adiungo\Core\Factories\Data_Sources\CSV::get_csv_instance
@@ -128,42 +31,6 @@ class CSV_Test extends Test_Case
     }
 
     /**
-     * @covers \Adiungo\Core\Factories\Data_Sources\CSV::map_column
-     * @return void
-     * @throws Operation_Failed
-     */
-    public function test_can_map_column(): void
-    {
-        $instance = Mockery::mock(CSV::class)->makePartial()->shouldAllowMockingProtectedMethods();
-        $column = 'foo';
-        $setter = 'bar';
-        $type = Types::String;
-        $instance->expects('get_mappings->add')->with($column, ['setter' => $setter, 'type' => $type]);
-
-        $this->assertSame($instance, $instance->map_column($column, $setter, $type));
-    }
-
-    /**
-     * @covers \Adiungo\Core\Factories\Data_Sources\CSV::map_column
-     * @return void
-     * @throws Operation_Failed
-     */
-    public function test_can_map_column_catches_thrown_exceptions(): void
-    {
-        $instance = Mockery::mock(CSV::class)->makePartial()->shouldAllowMockingProtectedMethods();
-        $column = 'foo';
-        $instance->allows('get_content_model_instance')->andReturn('Mocked_Model');
-        $setter = 'bar';
-        $type = Types::String;
-        $instance->expects('get_mappings->add')->with($column, ['setter' => $setter, 'type' => $type])->andThrow(Operation_Failed::class);
-
-        $this->expectException(Operation_Failed::class);
-        $this->expectExceptionMessage("Column mapping failed - The $setter method cannot be found on the Mocked_Model model.");
-
-        $instance->map_column($column, $setter, $type);
-    }
-
-    /**
      * @covers \Adiungo\Core\Factories\Data_Sources\CSV::set_csv
      * @throws ReflectionException
      */
@@ -176,12 +43,5 @@ class CSV_Test extends Test_Case
         $property = $this->get_protected_property($source, 'csv');
 
         $this->assertSame($expected, $property->getValue($source));
-    }
-
-    /** @see test_mapping_is_valid */
-    protected function provider_mapping_is_valid(): Generator
-    {
-        yield 'valid setter returns true' => [true, 'set_test_value'];
-        yield 'invalid setter returns false' => [false, 'invalid'];
     }
 }

--- a/tests/Unit/Traits/With_Data_Source_Adapter_Test.php
+++ b/tests/Unit/Traits/With_Data_Source_Adapter_Test.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Adiungo\Core\Tests\Unit\Traits;
+
+
+use Adiungo\Core\Factories\Adapters\Data_Source_Adapter;
+use Adiungo\Core\Traits\With_Data_Source_Adapter;
+use Adiungo\Tests\Test_Case;
+use Adiungo\Tests\Traits\With_Simple_Setter_Getter_Tests;
+use Generator;
+use Mockery;
+
+/**
+ * @covers \Adiungo\Core\Traits\With_Data_Source_Adapter::set_data_source
+ * @covers \Adiungo\Core\Traits\With_Data_Source_Adapter::get_data_source
+ */
+class With_Data_Source_Adapter_Test extends Test_Case
+{
+    use With_Simple_Setter_Getter_Tests;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->instance = Mockery::mock(With_Data_Source_Adapter::class);
+        $this->instance->shouldAllowMockingProtectedMethods()->makePartial();
+    }
+
+    protected function get_setters_and_getters(): Generator
+    {
+        yield 'data_source' => ['set_data_source_adapter', 'get_data_source_adapter', Mockery::mock(Data_Source_Adapter::class)];
+    }
+}

--- a/tests/Unit/Validate_CI_Test.php
+++ b/tests/Unit/Validate_CI_Test.php
@@ -5,7 +5,7 @@ namespace Adiungo\Core\Tests\Unit;
 
 use Adiungo\Tests\Test_Case;
 
-class Valdiate_CI_Test extends Test_Case
+class Validate_CI_Test extends Test_Case
 {
 
     /**


### PR DESCRIPTION
## Summary

Resolves #100 
Resolves #101 
Resolves #102 

## Details

This update completely removes the data source adapter functionality from the CSV class, puts it in a new class, and sets up the CSV class to interact with that class instead.

This will make it possible to use the `Data_Source_Adapter` class in other data sources, like the REST data source.

## Before Marking this PR as Ready to Review, I have verified that:

- [x] This PR fulfills the acceptance criteria detailed in the issue.
- [x] This PR matches the coding standards.
- [x] Related unit tests have been written, or updated to reflect the changes here.
- [x] All tests have passed.
- [x] I have filled out the "Testing" section with detailed instructions on how to test this PR
- [x] I have assigned this PR to myself
- [x] I have linked this PR to the issue it is intended to close.

## Before Merge, the Reviewer has verified that:

- [x] This PR fulfills the acceptance criteria detailed in the issue.
- [x] This PR matches the coding standards.
- [x] All unit tests have passed.
- [x] The code has been reviewed.
- [x] Any changes to the code has been appropriately covered in unit tests.