### PR TITLE
Issue/150 - Implement single response adapter in rest class

### DIFF
--- a/lib/Abstracts/Single_Response_Adapter.php
+++ b/lib/Abstracts/Single_Response_Adapter.php
@@ -4,9 +4,9 @@ namespace Adiungo\Core\Abstracts;
 
 use Adiungo\Core\Interfaces\Has_Response;
 use Adiungo\Core\Traits\With_Response;
-use Underpin\Interfaces\Can_Convert_To_Instance;
+use Underpin\Interfaces\Can_Convert_To_Array;
 
-abstract class Single_Response_Adapter implements Can_Convert_To_Instance, Has_Response
+abstract class Single_Response_Adapter implements Can_Convert_To_Array, Has_Response
 {
     use With_Response;
 }

--- a/lib/Factories/Adapters/Data_Source_Adapter.php
+++ b/lib/Factories/Adapters/Data_Source_Adapter.php
@@ -65,7 +65,7 @@ class Data_Source_Adapter implements Has_Content_Model_Instance
     /**
      * Converts a set of raw data into the model, using the mappings set in this class.
      *
-     * @param string[] $raw_model
+     * @param mixed[] $raw_model
      * @return Content_Model
      * @throws Operation_Failed
      */
@@ -79,9 +79,9 @@ class Data_Source_Adapter implements Has_Content_Model_Instance
         try {
             Array_Helper::each($raw_model, fn(mixed $item, string $key) => $this->set_mapped_property($key, $item, $model));
         } catch (TypeError $exception) {
-            throw new Operation_Failed("Could not adapt CSV to the model.", previous: $exception);
+            throw new Operation_Failed("Could not adapt to the model.", previous: $exception);
         } catch (Unknown_Registry_Item $exception) {
-            throw new Operation_Failed("Could not adapt CSV to the model because the mapped property was not set.", previous: $exception);
+            throw new Operation_Failed("Could not adapt to the model because the mapped property was not set.", previous: $exception);
         }
 
         return $model;

--- a/lib/Factories/Data_Sources/Rest.php
+++ b/lib/Factories/Data_Sources/Rest.php
@@ -13,6 +13,7 @@ use Adiungo\Core\Interfaces\Has_Data_Source_Adapter;
 use Adiungo\Core\Interfaces\Has_Has_More_Strategy;
 use Adiungo\Core\Interfaces\Has_Http_Strategy;
 use Adiungo\Core\Interfaces\Has_Single_Request_Builder;
+use Adiungo\Core\Interfaces\Has_Single_Response_Adapter;
 use Adiungo\Core\Traits\With_Batch_Request_Builder;
 use Adiungo\Core\Traits\With_Batch_Response_Adapter;
 use Adiungo\Core\Traits\With_Content_Model_Instance;
@@ -20,13 +21,13 @@ use Adiungo\Core\Traits\With_Data_Source_Adapter;
 use Adiungo\Core\Traits\With_Has_More_Strategy;
 use Adiungo\Core\Traits\With_Http_Strategy;
 use Adiungo\Core\Traits\With_Single_Request_Builder;
-use JsonException;
+use Adiungo\Core\Traits\With_Single_Response_Adapter;
 use Underpin\Exceptions\Operation_Failed;
 use Underpin\Factories\Request;
 use Underpin\Helpers\Array_Helper;
 use Underpin\Traits\With_Object_Cache;
 
-class Rest implements Data_Source, Has_Content_Model_Instance, Has_Http_Strategy, Has_Data_Source_Adapter, Has_Batch_Response_Adapter, Has_Has_More_Strategy, Has_Batch_Request_Builder, Has_Single_Request_Builder
+class Rest implements Data_Source, Has_Content_Model_Instance, Has_Http_Strategy, Has_Data_Source_Adapter, Has_Batch_Response_Adapter, Has_Single_Response_Adapter, Has_Has_More_Strategy, Has_Batch_Request_Builder, Has_Single_Request_Builder
 {
     use With_Content_Model_Instance;
     use With_Data_Source_Adapter;
@@ -36,6 +37,7 @@ class Rest implements Data_Source, Has_Content_Model_Instance, Has_Http_Strategy
     use With_Single_Request_Builder;
     use With_Batch_Request_Builder;
     use With_Http_Strategy;
+    use With_Single_Response_Adapter;
 
     public function get_data(): Content_Model_Collection
     {
@@ -78,14 +80,13 @@ class Rest implements Data_Source, Has_Content_Model_Instance, Has_Http_Strategy
      * @param int|string $id
      * @return Content_Model
      * @throws Operation_Failed
-     * @throws JsonException
      */
     public function get_item(int|string $id): Content_Model
     {
         return $this->load_from_cache('get_item', function () use ($id) {
-            $instance = $this->get_single_request_builder()->set_id($id)->get_request();
+            $request = $this->get_single_request_builder()->set_id($id)->get_request();
 
-            $data = Array_Helper::wrap(json_decode($this->get_response($instance), true, 512, JSON_THROW_ON_ERROR));
+            $data = $this->get_single_response_adapter()->set_response($this->get_response($request))->to_array();
 
             return $this->get_data_source_adapter()->convert_to_model($data);
         });

--- a/tests/Integration/Mocks/Single_Response_Adapter_Mock.php
+++ b/tests/Integration/Mocks/Single_Response_Adapter_Mock.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Adiungo\Core\Tests\Integration\Mocks;
+
+
+use Adiungo\Core\Abstracts\Single_Response_Adapter;
+
+class Single_Response_Adapter_Mock extends Single_Response_Adapter
+{
+    /**
+     * @return mixed[]
+     */
+    public function to_array(): array
+    {
+        return (array)json_decode($this->get_response(), true);
+    }
+}

--- a/tests/Integration/Rest_Data_Source_Test.php
+++ b/tests/Integration/Rest_Data_Source_Test.php
@@ -9,10 +9,10 @@ use Adiungo\Core\Tests\Integration\Mocks\Batch_Response_Adapter_Mock;
 use Adiungo\Core\Tests\Integration\Mocks\Has_More_Strategy_Mock;
 use Adiungo\Core\Tests\Integration\Mocks\Http_Strategy_Mock;
 use Adiungo\Core\Tests\Integration\Mocks\Single_Request_Builder;
+use Adiungo\Core\Tests\Integration\Mocks\Single_Response_Adapter_Mock;
 use Adiungo\Core\Tests\Integration\Mocks\Test_Data_Source_Adapter;
 use Adiungo\Core\Tests\Integration\Mocks\Test_Model;
 use Adiungo\Tests\Test_Case;
-use JsonException;
 use Underpin\Enums\Rest as Method;
 use Underpin\Enums\Types;
 use Underpin\Exceptions\Operation_Failed;
@@ -38,7 +38,8 @@ class Rest_Data_Source_Test extends Test_Case
             ->set_has_more_strategy(new Has_More_Strategy_Mock())
             ->set_http_strategy(new Http_Strategy_Mock())
             ->set_single_request_builder(new Single_Request_Builder())
-            ->set_batch_response_adapter(new Batch_Response_Adapter_Mock());
+            ->set_batch_response_adapter(new Batch_Response_Adapter_Mock())
+            ->set_single_response_adapter(new Single_Response_Adapter_Mock());
 
     }
 
@@ -86,7 +87,6 @@ class Rest_Data_Source_Test extends Test_Case
      * @throws Operation_Failed
      * @throws Url_Exception
      * @throws Validation_Failed
-     * @throws JsonException
      * @covers \Adiungo\Core\Factories\Data_Sources\Rest::get_item()
      */
     public function test_can_get_item(): void

--- a/tests/Unit/Factories/Data_Sources/Rest_Test.php
+++ b/tests/Unit/Factories/Data_Sources/Rest_Test.php
@@ -8,6 +8,7 @@ use Adiungo\Core\Abstracts\Content_Model;
 use Adiungo\Core\Abstracts\Has_More_Strategy;
 use Adiungo\Core\Abstracts\Http_Strategy;
 use Adiungo\Core\Abstracts\Int_Id_Based_Request_Builder;
+use Adiungo\Core\Abstracts\Single_Response_Adapter;
 use Adiungo\Core\Collections\Content_Model_Collection;
 use Adiungo\Core\Factories\Data_Sources\Rest;
 use Adiungo\Core\Interfaces\Has_Paginated_Request;
@@ -15,7 +16,6 @@ use Adiungo\Tests\Test_Case;
 use Adiungo\Tests\Traits\With_Inaccessible_Methods;
 use Adiungo\Tests\Traits\With_Inaccessible_Properties;
 use Generator;
-use JsonException;
 use Mockery;
 use ReflectionException;
 use Underpin\Exceptions\Operation_Failed;
@@ -135,7 +135,6 @@ class Rest_Test extends Test_Case
      * @covers \Adiungo\Core\Factories\Data_Sources\Rest::get_item
      * @return void
      * @throws Operation_Failed
-     * @throws JsonException
      */
     public function test_can_get_item(): void
     {
@@ -144,6 +143,10 @@ class Rest_Test extends Test_Case
         $response = '{"foo": "bar"}';
         $builder = Mockery::mock(Int_Id_Based_Request_Builder::class);
         $expected = Mockery::mock(Content_Model::class);
+        $adapter = Mockery::mock(Single_Response_Adapter::class);
+
+        $adapter->expects('set_response')->with($response);
+        $adapter->expects('to_array')->once()->andReturn([['foo' => 'bar']]);
 
         $builder->expects('set_id')->once()->andReturn($builder);
         $builder->expects('get_request')->once()->andReturn($request);
@@ -151,6 +154,7 @@ class Rest_Test extends Test_Case
         $instance->expects('get_single_request_builder')->once()->andReturn($builder);
         $instance->expects('get_response')->with($request)->once()->andReturn($response);
         $instance->expects('get_data_source_adapter->convert_to_model')->once()->andReturn($expected);
+        $instance->expects('get_single_response_adapter')->andReturn($adapter);
 
         $this->assertSame($instance->get_item(123), $expected);
         // Run twice to confirm the data is cached and does not run more than once.


### PR DESCRIPTION
## Summary

This PR implements the `Single_Response_Adapter` class into `Rest`, making it possible to adapt a REST response into something Adiungo understands.

## Before Marking this PR as Ready to Review, I have verified that:

- [x] This PR fulfills the acceptance criteria detailed in the issue.
- [x] This PR matches the coding standards.
- [x] Related unit tests have been written, or updated to reflect the changes here.
- [x] All tests have passed.
- [x] I have filled out the "Testing" section with detailed instructions on how to test this PR
- [x] I have assigned this PR to myself
- [x] I have linked this PR to the issue it is intended to close.

## Before Merge, the Reviewer has verified that:

- [x] This PR fulfills the acceptance criteria detailed in the issue.
- [x] This PR matches the coding standards.
- [x] All unit tests have passed.
- [x] The code has been reviewed.
- [x] Any changes to the code has been appropriately covered in unit tests.