### PR TITLE
Issue/155 - Update Data_Source_Adapter::map_field to support callbacks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,9 @@
     "readme": "README.md",
     "license": "MIT",
     "scripts": {
-        "php-cs-fixer": "php-cs-fixer fix"
+        "php-cs-fixer": "php-cs-fixer fix",
+        "phpstan": "vendor/bin/phpstan analyse lib tests --level=9",
+        "phpunit": " vendor/bin/phpunit --configuration=phpunit.xml"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -44,5 +44,11 @@
     },
     "require-dev": {
         "adiungo/tests": "^0.1.0"
+    },
+    "config": {
+        "allow-plugins": {
+            "composer/installers": true,
+            "phpstan/extension-installer": true
+        }
     }
 }

--- a/lib/Factories/Adapters/Data_Source_Adapter.php
+++ b/lib/Factories/Adapters/Data_Source_Adapter.php
@@ -48,7 +48,7 @@ class Data_Source_Adapter implements Has_Content_Model_Instance
      */
     public function get_mappings(): Registry
     {
-        return $this->load_from_cache('mappings', fn() => new Registry(fn($key, $value) => $this->mapping_is_valid($value['setter'], $value['type'])));
+        return $this->load_from_cache('mappings', fn () => new Registry(fn ($key, $value) => $this->mapping_is_valid($value['setter'], $value['type'])));
     }
 
     /**
@@ -60,7 +60,7 @@ class Data_Source_Adapter implements Has_Content_Model_Instance
      */
     protected function mapping_is_valid(string $setter, Types|Closure $type): bool
     {
-        return method_exists($this->get_content_model_instance(), $setter) && ($type instanceof Types || $type instanceof Closure);
+        return method_exists($this->get_content_model_instance(), $setter);
     }
 
     /**
@@ -78,7 +78,7 @@ class Data_Source_Adapter implements Has_Content_Model_Instance
         $model = new $model();
 
         try {
-            Array_Helper::each($raw_model, fn(mixed $item, string $key) => $this->set_mapped_property($key, $item, $model));
+            Array_Helper::each($raw_model, fn (mixed $item, string $key) => $this->set_mapped_property($key, $item, $model));
         } catch (TypeError $exception) {
             throw new Operation_Failed("Could not adapt to the model.", previous: $exception);
         } catch (Unknown_Registry_Item $exception) {
@@ -97,7 +97,7 @@ class Data_Source_Adapter implements Has_Content_Model_Instance
      */
     protected function set_mapped_property(string $key, mixed $item, Content_Model $model): void
     {
-        /** @var array{type:Types, setter:string} $mapping */
+        /** @var array{type:Types|Closure, setter:string} $mapping */
         $mapping = $this->get_mappings()->get($key);
 
         if ($mapping['type'] instanceof Closure) {

--- a/tests/Integration/Mocks/Test_Data_Source_Adapter.php
+++ b/tests/Integration/Mocks/Test_Data_Source_Adapter.php
@@ -2,8 +2,11 @@
 
 namespace Adiungo\Core\Tests\Integration\Mocks;
 
+use Adiungo\Core\Collections\Category_Collection;
 use Adiungo\Core\Factories\Adapters\Data_Source_Adapter;
+use Adiungo\Core\Factories\Category;
 use Underpin\Enums\Types;
+use Underpin\Helpers\Array_Helper;
 
 class Test_Data_Source_Adapter extends Data_Source_Adapter
 {
@@ -12,6 +15,10 @@ class Test_Data_Source_Adapter extends Data_Source_Adapter
         $this->set_content_model_instance(Test_Model::class)
             ->map_field('content', 'set_content', Types::String)
             ->map_field('name', 'set_name', Types::String)
+            ->map_field(
+                'categories', 'add_categories',
+                fn(array $categories) => Array_Helper::map($categories, fn(int $category) => (new Category())->set_id($category))
+            )
             ->map_field('id', 'set_id', Types::Integer);
     }
 }

--- a/tests/Integration/Mocks/Test_Data_Source_Adapter.php
+++ b/tests/Integration/Mocks/Test_Data_Source_Adapter.php
@@ -16,8 +16,9 @@ class Test_Data_Source_Adapter extends Data_Source_Adapter
             ->map_field('content', 'set_content', Types::String)
             ->map_field('name', 'set_name', Types::String)
             ->map_field(
-                'categories', 'add_categories',
-                fn(array $categories) => Array_Helper::map($categories, fn(int $category) => (new Category())->set_id($category))
+                'categories',
+                'add_categories',
+                fn (array $categories) => Array_Helper::map($categories, fn (string|null $category) => (new Category())->set_id($category))
             )
             ->map_field('id', 'set_id', Types::Integer);
     }

--- a/tests/Integration/Mocks/Test_Model.php
+++ b/tests/Integration/Mocks/Test_Model.php
@@ -3,16 +3,19 @@
 namespace Adiungo\Core\Tests\Integration\Mocks;
 
 use Adiungo\Core\Abstracts\Content_Model;
+use Adiungo\Core\Interfaces\Has_Categories;
 use Adiungo\Core\Interfaces\Has_Content;
 use Adiungo\Core\Interfaces\Has_Name;
+use Adiungo\Core\Traits\With_Categories;
 use Adiungo\Core\Traits\With_Content;
 use Adiungo\Core\Traits\With_Name;
 use Underpin\Interfaces\Identifiable_Int;
 use Underpin\Traits\With_Int_Identity;
 
-final class Test_Model extends Content_Model implements Has_Name, Has_Content, Identifiable_Int
+final class Test_Model extends Content_Model implements Has_Name, Has_Content, Identifiable_Int, Has_Categories
 {
     use With_Content;
     use With_Name;
     use With_Int_Identity;
+    use With_Categories;
 }

--- a/tests/Integration/Mocks/batch-response-1.json
+++ b/tests/Integration/Mocks/batch-response-1.json
@@ -3,26 +3,31 @@
     "items": [
         {
             "content": "This is item 1 content",
+            "categories": [1,2],
             "name": "This is item 1",
             "id": 1
         },
         {
             "content": "This is item 2 content",
+            "categories": [2,3],
             "name": "This is item 2",
             "id": 2
         },
         {
             "content": "This is item 3 content",
+            "categories": [3,4],
             "name": "This is item 3",
             "id": 3
         },
         {
             "content": "This is item 4 content",
+            "categories": [4,5],
             "name": "This is item 4",
             "id": 4
         },
         {
             "content": "This is item 5 content",
+            "categories": [5,6],
             "name": "This is item 5",
             "id": 5
         }

--- a/tests/Integration/Mocks/batch-response-1.json
+++ b/tests/Integration/Mocks/batch-response-1.json
@@ -3,31 +3,31 @@
     "items": [
         {
             "content": "This is item 1 content",
-            "categories": [1,2],
+            "categories": ["1","2"],
             "name": "This is item 1",
             "id": 1
         },
         {
             "content": "This is item 2 content",
-            "categories": [2,3],
+            "categories": ["2","3"],
             "name": "This is item 2",
             "id": 2
         },
         {
             "content": "This is item 3 content",
-            "categories": [3,4],
+            "categories": ["3","4"],
             "name": "This is item 3",
             "id": 3
         },
         {
             "content": "This is item 4 content",
-            "categories": [4,5],
+            "categories": ["4","5"],
             "name": "This is item 4",
             "id": 4
         },
         {
             "content": "This is item 5 content",
-            "categories": [5,6],
+            "categories": ["5","6"],
             "name": "This is item 5",
             "id": 5
         }

--- a/tests/Integration/Mocks/batch-response-2.json
+++ b/tests/Integration/Mocks/batch-response-2.json
@@ -3,26 +3,31 @@
     "items": [
         {
             "content": "This is item 6 content",
+            "categories": [6,7],
             "name": "This is item 6",
             "id": 6
         },
         {
             "content": "This is item 7 content",
+            "categories": [7,8],
             "name": "This is item 7",
             "id": 7
         },
         {
             "content": "This is item 8 content",
+            "categories": [8,9],
             "name": "This is item 8",
             "id": 8
         },
         {
             "content": "This is item 9 content",
+            "categories": [9,10],
             "name": "This is item 9",
             "id": 9
         },
         {
             "content": "This is item 10 content",
+            "categories": [10,11],
             "name": "This is item 10",
             "id": 10
         }

--- a/tests/Integration/Mocks/batch-response-2.json
+++ b/tests/Integration/Mocks/batch-response-2.json
@@ -3,31 +3,31 @@
     "items": [
         {
             "content": "This is item 6 content",
-            "categories": [6,7],
+            "categories": ["6","7"],
             "name": "This is item 6",
             "id": 6
         },
         {
             "content": "This is item 7 content",
-            "categories": [7,8],
+            "categories": ["7","8"],
             "name": "This is item 7",
             "id": 7
         },
         {
             "content": "This is item 8 content",
-            "categories": [8,9],
+            "categories": ["8","9"],
             "name": "This is item 8",
             "id": 8
         },
         {
             "content": "This is item 9 content",
-            "categories": [9,10],
+            "categories": ["9","10"],
             "name": "This is item 9",
             "id": 9
         },
         {
             "content": "This is item 10 content",
-            "categories": [10,11],
+            "categories": ["10","11"],
             "name": "This is item 10",
             "id": 10
         }

--- a/tests/Integration/Mocks/single-response.json
+++ b/tests/Integration/Mocks/single-response.json
@@ -1,5 +1,6 @@
 {
     "content": "This is item 5 content",
     "name": "This is item 5",
+    "categories": [5,6],
     "id": 5
 }

--- a/tests/Integration/Rest_Data_Source_Test.php
+++ b/tests/Integration/Rest_Data_Source_Test.php
@@ -79,8 +79,8 @@ class Rest_Data_Source_Test extends Test_Case
         return (new Test_Model())
             ->set_id($id)
             ->set_content("This is item $id content")
-            ->add_categories((new Category())->set_id($id))
-            ->add_categories((new Category())->set_id($id + 1))
+            ->add_categories((new Category())->set_id((string) $id))
+            ->add_categories((new Category())->set_id((string) ($id + 1)))
             ->set_name("This is item $id");
     }
 

--- a/tests/Integration/Rest_Data_Source_Test.php
+++ b/tests/Integration/Rest_Data_Source_Test.php
@@ -3,6 +3,7 @@
 namespace Adiungo\Core\Tests\Integration;
 
 use Adiungo\Core\Collections\Content_Model_Collection;
+use Adiungo\Core\Factories\Category;
 use Adiungo\Core\Factories\Data_Sources\Rest;
 use Adiungo\Core\Tests\Integration\Mocks\Batch_Request_Builder;
 use Adiungo\Core\Tests\Integration\Mocks\Batch_Response_Adapter_Mock;
@@ -71,12 +72,15 @@ class Rest_Data_Source_Test extends Test_Case
      * Constructs a test model based on the provided ID.
      * @param int $id
      * @return Test_Model
+     * @throws Operation_Failed
      */
     protected function build_model(int $id): Test_Model
     {
         return (new Test_Model())
             ->set_id($id)
             ->set_content("This is item $id content")
+            ->add_categories((new Category())->set_id($id))
+            ->add_categories((new Category())->set_id($id + 1))
             ->set_name("This is item $id");
     }
 

--- a/tests/Unit/Factories/Adapters/Data_Source_Adapter_Test.php
+++ b/tests/Unit/Factories/Adapters/Data_Source_Adapter_Test.php
@@ -67,8 +67,8 @@ class Data_Source_Adapter_Test extends Test_Case
     {
         yield 'it converts types' => [6, '6', ['setter' => 'set_int', 'type' => Types::Integer]];
         yield 'it sets values' => ['alex', 'alex', ['setter' => 'set_name', 'type' => Types::String]];
-        yield 'it converts types with closures' => [1000, '6', ['setter' => 'set_int', 'type' => fn() => 1000]];
-        yield 'it sets values with closures' => ['Alex', 'alex', ['setter' => 'set_name', 'type' => fn() => 'Alex']];
+        yield 'it converts types with closures' => [1000, '6', ['setter' => 'set_int', 'type' => fn () => 1000]];
+        yield 'it sets values with closures' => ['Alex', 'alex', ['setter' => 'set_name', 'type' => fn () => 'Alex']];
     }
 
     /**
@@ -151,7 +151,7 @@ class Data_Source_Adapter_Test extends Test_Case
     /** @see test_can_map_field */
     public function provider_map_field(): Generator
     {
-        yield 'supports closure' => [fn() => 'test'];
+        yield 'supports closure' => [fn () => 'test'];
         yield 'supports type' => [Types::String];
     }
 
@@ -160,7 +160,7 @@ class Data_Source_Adapter_Test extends Test_Case
     {
         yield 'valid setter returns true with Type' => [true, 'set_test_value', Types::String];
         yield 'valid setter returns false with Type and invalid setter.' => [false, 'invalid', Types::String];
-        yield 'invalid setter returns true with closure' => [true, 'set_test_value', fn() => 'foo'];
-        yield 'invalid setter returns false with closure and invalid setter.' => [false, 'invalid', fn() => 'foo'];
+        yield 'invalid setter returns true with closure' => [true, 'set_test_value', fn () => 'foo'];
+        yield 'invalid setter returns false with closure and invalid setter.' => [false, 'invalid', fn () => 'foo'];
     }
 }


### PR DESCRIPTION
## Summary

Resolves #155 

This PR updates `Data_Source_Adapter::map_field` to support using a Closure to handle casting a field.

## Testing

<!-- Add steps to test this PR here. Remove the "Testing" Heading if there are no testing steps to make. -->

## Before Marking this PR as Ready to Review, I have verified that:

- [x] This PR fulfills the acceptance criteria detailed in the issue.
- [x] This PR matches the coding standards.
- [x] Related unit tests have been written, or updated to reflect the changes here.
- [x] All tests have passed.
- [x] I have filled out the "Testing" section with detailed instructions on how to test this PR
- [x] I have assigned this PR to myself
- [x] I have linked this PR to the issue it is intended to close.

## Before Merge, the Reviewer has verified that:

- [x] This PR fulfills the acceptance criteria detailed in the issue.
- [x] This PR matches the coding standards.
- [x] All unit tests have passed.
- [x] The code has been reviewed.
- [x] Any changes to the code has been appropriately covered in unit tests.