### PR TITLE
Issue/154 - Rewrite Data_Source_Adapter::set_mapped_property to loop through registry instead of model

### DIFF
--- a/lib/Factories/Adapters/Data_Source_Adapter.php
+++ b/lib/Factories/Adapters/Data_Source_Adapter.php
@@ -50,7 +50,7 @@ class Data_Source_Adapter implements Has_Content_Model_Instance
      */
     public function get_mappings(): Registry
     {
-        return $this->load_from_cache('mappings', fn() => new Registry(fn($key, $value) => $this->mapping_is_valid($value['setter'], $value['type'])));
+        return $this->load_from_cache('mappings', fn () => new Registry(fn ($key, $value) => $this->mapping_is_valid($value['setter'], $value['type'])));
     }
 
     /**
@@ -80,8 +80,7 @@ class Data_Source_Adapter implements Has_Content_Model_Instance
         $model = new $model();
 
         try {
-            /** @var array{type:Types|Closure, setter:string} $mapping */
-            $this->get_mappings()->each(fn(array $mapping, string $key) => $this->set_mapped_property($key, $mapping['type'], $mapping['setter'], $raw_model, $model));
+            $this->get_mappings()->each(fn (array $mapping, string $key) => $this->set_mapped_property($key, $mapping['type'], $mapping['setter'], $raw_model, $model));
         } catch (TypeError $exception) {
             throw new Operation_Failed("Could not adapt to the model.", previous: $exception);
         } catch (Item_Not_Found $exception) {
@@ -95,7 +94,7 @@ class Data_Source_Adapter implements Has_Content_Model_Instance
      * @param string $key
      * @param Types|Closure $type
      * @param string $setter
-     * @param array $raw_model
+     * @param mixed[] $raw_model
      * @param Content_Model $model
      * @return void
      * @throws Item_Not_Found
@@ -104,9 +103,9 @@ class Data_Source_Adapter implements Has_Content_Model_Instance
     {
         if (str_contains($key, '.')) {
             $item = Array_Helper::dot($raw_model, $key);
-        } elseif(isset($raw_model[$key])){
+        } elseif (isset($raw_model[$key])) {
             $item = $raw_model[$key];
-        }else{
+        } else {
             // Bail. This key is not in the raw model.
             return;
         }

--- a/tests/Integration/CSV_Data_Source_Test.php
+++ b/tests/Integration/CSV_Data_Source_Test.php
@@ -22,7 +22,7 @@ class CSV_Data_Source_Test extends Test_Case
     public function test_can_get_item(): void
     {
         $item = (new CSV())
-            ->set_data_source_adapter(new Test_Data_Source_Adapter())
+            ->set_data_source_adapter(new Test_Data_Source_Adapter(true))
             ->set_csv("id,content,name\r1,\"the content\",alex\r2,\"more content\",stephen")
             ->get_item(2);
 

--- a/tests/Integration/Mocks/Test_Data_Source_Adapter.php
+++ b/tests/Integration/Mocks/Test_Data_Source_Adapter.php
@@ -2,7 +2,6 @@
 
 namespace Adiungo\Core\Tests\Integration\Mocks;
 
-use Adiungo\Core\Collections\Category_Collection;
 use Adiungo\Core\Factories\Adapters\Data_Source_Adapter;
 use Adiungo\Core\Factories\Category;
 use Underpin\Enums\Types;
@@ -10,10 +9,10 @@ use Underpin\Helpers\Array_Helper;
 
 class Test_Data_Source_Adapter extends Data_Source_Adapter
 {
-    public function __construct()
+    public function __construct(bool $is_csv = false)
     {
         $this->set_content_model_instance(Test_Model::class)
-            ->map_field('content', 'set_content', Types::String)
+            ->map_field($is_csv ? 'content' : 'content.rendered', 'set_content', Types::String)
             ->map_field('name', 'set_name', Types::String)
             ->map_field(
                 'categories',

--- a/tests/Integration/Mocks/batch-response-1.json
+++ b/tests/Integration/Mocks/batch-response-1.json
@@ -2,31 +2,32 @@
     "found_items": 5,
     "items": [
         {
-            "content": "This is item 1 content",
+            "content": {"rendered":  "This is item 1 content"},
             "categories": ["1","2"],
             "name": "This is item 1",
             "id": 1
         },
         {
-            "content": "This is item 2 content",
+            "content": {"rendered":  "This is item 2 content"},
+            "not_used": "This value is not used, and should be ignored by the process.",
             "categories": ["2","3"],
             "name": "This is item 2",
             "id": 2
         },
         {
-            "content": "This is item 3 content",
+            "content": {"rendered":  "This is item 3 content"},
             "categories": ["3","4"],
             "name": "This is item 3",
             "id": 3
         },
         {
-            "content": "This is item 4 content",
+            "content": {"rendered":  "This is item 4 content"},
             "categories": ["4","5"],
             "name": "This is item 4",
             "id": 4
         },
         {
-            "content": "This is item 5 content",
+            "content": {"rendered":  "This is item 5 content"},
             "categories": ["5","6"],
             "name": "This is item 5",
             "id": 5

--- a/tests/Integration/Mocks/batch-response-2.json
+++ b/tests/Integration/Mocks/batch-response-2.json
@@ -2,31 +2,31 @@
     "found_items": 5,
     "items": [
         {
-            "content": "This is item 6 content",
+            "content": {"rendered":  "This is item 6 content"},
             "categories": ["6","7"],
             "name": "This is item 6",
             "id": 6
         },
         {
-            "content": "This is item 7 content",
+            "content": {"rendered":  "This is item 7 content"},
             "categories": ["7","8"],
             "name": "This is item 7",
             "id": 7
         },
         {
-            "content": "This is item 8 content",
+            "content": {"rendered":  "This is item 8 content"},
             "categories": ["8","9"],
             "name": "This is item 8",
             "id": 8
         },
         {
-            "content": "This is item 9 content",
+            "content": {"rendered":  "This is item 9 content"},
             "categories": ["9","10"],
             "name": "This is item 9",
             "id": 9
         },
         {
-            "content": "This is item 10 content",
+            "content": {"rendered":  "This is item 10 content"},
             "categories": ["10","11"],
             "name": "This is item 10",
             "id": 10

--- a/tests/Integration/Mocks/single-response.json
+++ b/tests/Integration/Mocks/single-response.json
@@ -1,5 +1,6 @@
 {
-    "content": "This is item 5 content",
+    "content": {"rendered": "This is item 5 content"},
+    "invalid": "Should be ignored!",
     "name": "This is item 5",
     "categories": [5,6],
     "id": 5

--- a/tests/Unit/Factories/Adapters/Data_Source_Adapter_Test.php
+++ b/tests/Unit/Factories/Adapters/Data_Source_Adapter_Test.php
@@ -4,6 +4,7 @@ namespace Adiungo\Core\Tests\Unit\Factories\Adapters;
 
 use Adiungo\Core\Abstracts\Content_Model;
 use Adiungo\Core\Factories\Adapters\Data_Source_Adapter;
+use Adiungo\Core\Tests\Integration\Mocks\Test_Model;
 use Adiungo\Tests\Test_Case;
 use Adiungo\Tests\Traits\With_Inaccessible_Methods;
 use Closure;
@@ -11,6 +12,7 @@ use Generator;
 use Mockery;
 use ReflectionException;
 use Underpin\Enums\Types;
+use Underpin\Exceptions\Item_Not_Found;
 use Underpin\Exceptions\Operation_Failed;
 use Underpin\Factories\Registry;
 
@@ -22,6 +24,7 @@ class Data_Source_Adapter_Test extends Test_Case
      * @covers \Adiungo\Core\Factories\Data_Sources\CSV::convert_to_model
      *
      * @throws ReflectionException
+     * @throws Operation_Failed
      */
     public function test_can_convert_to_model(): void
     {
@@ -29,46 +32,48 @@ class Data_Source_Adapter_Test extends Test_Case
 
         Mockery::namedMock('Test_Mock', Content_Model::class);
 
-        $items = ['a' => 'set_a', 'b' => 'set_b', 'c' => 'set_c', 'd' => 'set_d'];
+        $items = [
+            'foo' => ['type' => Types::String, 'setter' => 'baz'],
+            'foofoo' => ['type' => Types::String, 'setter' => 'bazbaz'],
+        ];
 
-        $instance->expects('set_mapped_property')->times(count($items))->withArgs(function ($key, $item, $model) use ($items) {
-            if ("Test_Mock" instanceof $model) {
-                return false;
-            }
+        $raw = ['foo' => 'bar', 'foofoo' => 'barbar'];
 
-            return $items[$key] === $item;
-        });
+        $instance->expects('set_mapped_property')->times(count($items));
         $instance->allows('get_content_model_instance')->andReturn('Test_Mock');
-
-        $this->call_inaccessible_method($instance, 'convert_to_model', $items);
+        $instance->allows('get_mappings')->andReturn((new Registry(fn() => true))->seed($items));
+        $this->call_inaccessible_method($instance, 'convert_to_model', $raw);
     }
 
     /**
      * @covers       \Adiungo\Core\Factories\Data_Sources\CSV::set_mapped_property()
      *
      * @param mixed $expected
-     * @param mixed $value
-     * @param array{type:Types, setter:string} $mapping
+     * @param array $raw_model
+     * @param string $setter
+     * @param Types|Closure $type
+     * @param string $key
      * @throws ReflectionException
      * @dataProvider provider_set_mapped_property
      */
-    public function test_can_set_mapped_property(mixed $expected, mixed $value, array $mapping): void
+    public function test_can_set_mapped_property(mixed $expected, array $raw_model, string $setter, Types|Closure $type, string $key): void
     {
         $source = Mockery::mock(Data_Source_Adapter::class)->shouldAllowMockingProtectedMethods()->makePartial();
-        $source->allows('get_mappings->get')->with('key')->andReturn($mapping);
 
         $model = Mockery::mock(Content_Model::class);
-        $model->expects($mapping['setter'])->with($expected)->andReturn($model);
+        $model->expects($setter)->with($expected)->andReturn($model);
 
-        $this->call_inaccessible_method($source, 'set_mapped_property', 'key', $value, $model);
+        $this->call_inaccessible_method($source, 'set_mapped_property', $key, $type, $setter, $raw_model, $model);
     }
 
     public function provider_set_mapped_property(): Generator
     {
-        yield 'it converts types' => [6, '6', ['setter' => 'set_int', 'type' => Types::Integer]];
-        yield 'it sets values' => ['alex', 'alex', ['setter' => 'set_name', 'type' => Types::String]];
-        yield 'it converts types with closures' => [1000, '6', ['setter' => 'set_int', 'type' => fn () => 1000]];
-        yield 'it sets values with closures' => ['Alex', 'alex', ['setter' => 'set_name', 'type' => fn () => 'Alex']];
+        yield 'it converts types' => [6, ['key' => '6'], 'set_int', Types::Integer, 'key'];
+        yield 'it sets values' => ['alex', ['key' => 'alex'], 'set_name', Types::String, 'key'];
+        yield 'it sets dotted values' => [6, ['key' => ['subkey' => ['int' => 6]]], 'set_name', Types::Integer, 'key.subkey.int'];
+        yield 'it converts types with closures' => [1000, ['key' => '6'], 'set_int', fn() => 1000, 'key'];
+        yield 'it sets values with closures' => ['Alex', ['key' => 'alex'], 'set_name', fn() => 'Alex', 'key'];
+        yield 'it sets dotted values with closures' => ['AleX', ['key' => ['subkey' => 'alex']], 'set_name', fn() => 'AleX', 'key.subkey'];
     }
 
     /**
@@ -151,7 +156,7 @@ class Data_Source_Adapter_Test extends Test_Case
     /** @see test_can_map_field */
     public function provider_map_field(): Generator
     {
-        yield 'supports closure' => [fn () => 'test'];
+        yield 'supports closure' => [fn() => 'test'];
         yield 'supports type' => [Types::String];
     }
 
@@ -160,7 +165,7 @@ class Data_Source_Adapter_Test extends Test_Case
     {
         yield 'valid setter returns true with Type' => [true, 'set_test_value', Types::String];
         yield 'valid setter returns false with Type and invalid setter.' => [false, 'invalid', Types::String];
-        yield 'invalid setter returns true with closure' => [true, 'set_test_value', fn () => 'foo'];
-        yield 'invalid setter returns false with closure and invalid setter.' => [false, 'invalid', fn () => 'foo'];
+        yield 'invalid setter returns true with closure' => [true, 'set_test_value', fn() => 'foo'];
+        yield 'invalid setter returns false with closure and invalid setter.' => [false, 'invalid', fn() => 'foo'];
     }
 }

--- a/tests/Unit/Factories/Adapters/Data_Source_Adapter_Test.php
+++ b/tests/Unit/Factories/Adapters/Data_Source_Adapter_Test.php
@@ -41,7 +41,7 @@ class Data_Source_Adapter_Test extends Test_Case
 
         $instance->expects('set_mapped_property')->times(count($items));
         $instance->allows('get_content_model_instance')->andReturn('Test_Mock');
-        $instance->allows('get_mappings')->andReturn((new Registry(fn() => true))->seed($items));
+        $instance->allows('get_mappings')->andReturn((new Registry(fn () => true))->seed($items));
         $this->call_inaccessible_method($instance, 'convert_to_model', $raw);
     }
 
@@ -49,7 +49,7 @@ class Data_Source_Adapter_Test extends Test_Case
      * @covers       \Adiungo\Core\Factories\Data_Sources\CSV::set_mapped_property()
      *
      * @param mixed $expected
-     * @param array $raw_model
+     * @param mixed[] $raw_model
      * @param string $setter
      * @param Types|Closure $type
      * @param string $key
@@ -71,9 +71,9 @@ class Data_Source_Adapter_Test extends Test_Case
         yield 'it converts types' => [6, ['key' => '6'], 'set_int', Types::Integer, 'key'];
         yield 'it sets values' => ['alex', ['key' => 'alex'], 'set_name', Types::String, 'key'];
         yield 'it sets dotted values' => [6, ['key' => ['subkey' => ['int' => 6]]], 'set_name', Types::Integer, 'key.subkey.int'];
-        yield 'it converts types with closures' => [1000, ['key' => '6'], 'set_int', fn() => 1000, 'key'];
-        yield 'it sets values with closures' => ['Alex', ['key' => 'alex'], 'set_name', fn() => 'Alex', 'key'];
-        yield 'it sets dotted values with closures' => ['AleX', ['key' => ['subkey' => 'alex']], 'set_name', fn() => 'AleX', 'key.subkey'];
+        yield 'it converts types with closures' => [1000, ['key' => '6'], 'set_int', fn () => 1000, 'key'];
+        yield 'it sets values with closures' => ['Alex', ['key' => 'alex'], 'set_name', fn () => 'Alex', 'key'];
+        yield 'it sets dotted values with closures' => ['AleX', ['key' => ['subkey' => 'alex']], 'set_name', fn () => 'AleX', 'key.subkey'];
     }
 
     /**
@@ -156,7 +156,7 @@ class Data_Source_Adapter_Test extends Test_Case
     /** @see test_can_map_field */
     public function provider_map_field(): Generator
     {
-        yield 'supports closure' => [fn() => 'test'];
+        yield 'supports closure' => [fn () => 'test'];
         yield 'supports type' => [Types::String];
     }
 
@@ -165,7 +165,7 @@ class Data_Source_Adapter_Test extends Test_Case
     {
         yield 'valid setter returns true with Type' => [true, 'set_test_value', Types::String];
         yield 'valid setter returns false with Type and invalid setter.' => [false, 'invalid', Types::String];
-        yield 'invalid setter returns true with closure' => [true, 'set_test_value', fn() => 'foo'];
-        yield 'invalid setter returns false with closure and invalid setter.' => [false, 'invalid', fn() => 'foo'];
+        yield 'invalid setter returns true with closure' => [true, 'set_test_value', fn () => 'foo'];
+        yield 'invalid setter returns false with closure and invalid setter.' => [false, 'invalid', fn () => 'foo'];
     }
 }


### PR DESCRIPTION
## Summary

Resolves #154 

This PR rewrites `set_mapped_property` to expect, and work with the information in a different fashion than originally created. This makes it a lot easier to work with a dotted string, and also helps accomplish the goal of only adding necessary params instead of requiring everything all the time.

## Testing

<!-- Add steps to test this PR here. Remove the "Testing" Heading if there are no testing steps to make. -->

## Before Marking this PR as Ready to Review, I have verified that:

- [x] This PR fulfills the acceptance criteria detailed in the issue.
- [x] This PR matches the coding standards.
- [x] Related unit tests have been written, or updated to reflect the changes here.
- [x] All tests have passed.
- [x] I have filled out the "Testing" section with detailed instructions on how to test this PR
- [x] I have assigned this PR to myself
- [x] I have linked this PR to the issue it is intended to close.

## Before Merge, the Reviewer has verified that:

- [x] This PR fulfills the acceptance criteria detailed in the issue.
- [x] This PR matches the coding standards.
- [x] All unit tests have passed.
- [x] The code has been reviewed.
- [x] Any changes to the code has been appropriately covered in unit tests.