### PR TITLE
Issue/158 adds a check in Data_Source_Adapter::set_mapped_property when a closure is used

### DIFF
--- a/lib/Factories/Adapters/Data_Source_Adapter.php
+++ b/lib/Factories/Adapters/Data_Source_Adapter.php
@@ -50,7 +50,7 @@ class Data_Source_Adapter implements Has_Content_Model_Instance
      */
     public function get_mappings(): Registry
     {
-        return $this->load_from_cache('mappings', fn() => new Registry(fn($key, $value) => $this->mapping_is_valid($value['setter'], $value['type'])));
+        return $this->load_from_cache('mappings', fn () => new Registry(fn ($key, $value) => $this->mapping_is_valid($value['setter'], $value['type'])));
     }
 
     /**
@@ -80,7 +80,7 @@ class Data_Source_Adapter implements Has_Content_Model_Instance
         $model = new $model();
 
         try {
-            $this->get_mappings()->each(fn(array $mapping, string $key) => $this->set_mapped_property($key, $mapping['type'], $mapping['setter'], $raw_model, $model));
+            $this->get_mappings()->each(fn (array $mapping, string $key) => $this->set_mapped_property($key, $mapping['type'], $mapping['setter'], $raw_model, $model));
         } catch (TypeError $exception) {
             throw new Operation_Failed("Could not adapt to the model.", previous: $exception);
         } catch (Item_Not_Found $exception) {

--- a/lib/Factories/Adapters/Data_Source_Adapter.php
+++ b/lib/Factories/Adapters/Data_Source_Adapter.php
@@ -50,7 +50,7 @@ class Data_Source_Adapter implements Has_Content_Model_Instance
      */
     public function get_mappings(): Registry
     {
-        return $this->load_from_cache('mappings', fn () => new Registry(fn ($key, $value) => $this->mapping_is_valid($value['setter'], $value['type'])));
+        return $this->load_from_cache('mappings', fn() => new Registry(fn($key, $value) => $this->mapping_is_valid($value['setter'], $value['type'])));
     }
 
     /**
@@ -80,7 +80,7 @@ class Data_Source_Adapter implements Has_Content_Model_Instance
         $model = new $model();
 
         try {
-            $this->get_mappings()->each(fn (array $mapping, string $key) => $this->set_mapped_property($key, $mapping['type'], $mapping['setter'], $raw_model, $model));
+            $this->get_mappings()->each(fn(array $mapping, string $key) => $this->set_mapped_property($key, $mapping['type'], $mapping['setter'], $raw_model, $model));
         } catch (TypeError $exception) {
             throw new Operation_Failed("Could not adapt to the model.", previous: $exception);
         } catch (Item_Not_Found $exception) {
@@ -112,6 +112,11 @@ class Data_Source_Adapter implements Has_Content_Model_Instance
 
         if ($type instanceof Closure) {
             $item = $type($item);
+
+            if (is_array($item) && empty($item)) {
+                return;
+            }
+
             $model->{$setter}(...Array_Helper::wrap($item));
         } else {
             settype($item, $type->value);

--- a/tests/Integration/Mocks/batch-response-3.json
+++ b/tests/Integration/Mocks/batch-response-3.json
@@ -1,0 +1,42 @@
+{
+    "found_items": 5,
+    "items": [
+        {
+            "content": {"rendered":  "This is item 1 content"},
+            "categories": ["1","2"],
+            "name": "This is item 1",
+            "id": 1
+        },
+        {
+            "content": {"rendered":  "This is item 2 content"},
+            "not_used": "This value is not used, and should be ignored by the process.",
+            "categories": ["2","3"],
+            "name": "This is item 2",
+            "id": 2
+        },
+        {
+            "content": {"rendered":  "This is item 3 content"},
+            "categories": ["3","4"],
+            "name": "This is item 3",
+            "id": 3
+        },
+        {
+            "content": {"rendered":  "This is item 4 content"},
+            "categories": ["4","5"],
+            "name": "This is item 4",
+            "id": 4
+        },
+        {
+            "content": {"rendered":  "This is item 5 content"},
+            "categories": ["5","6"],
+            "name": "This is item 5",
+            "id": 5
+        },
+        {
+            "content": {"rendered":  "This is item 6 content"},
+            "categories": [],
+            "name": "This is item 6",
+            "id": 6
+        }
+    ]
+}

--- a/tests/Integration/Rest_Data_Source_Test.php
+++ b/tests/Integration/Rest_Data_Source_Test.php
@@ -72,7 +72,7 @@ class Rest_Data_Source_Test extends Test_Case
     /**
      * Constructs a test model based on the provided ID.
      * @param int $id
-     * @param array|null $categories
+     * @param int[]|null $categories
      * @return Test_Model
      * @throws Operation_Failed
      */

--- a/tests/Integration/Rest_Data_Source_Test.php
+++ b/tests/Integration/Rest_Data_Source_Test.php
@@ -54,7 +54,7 @@ class Rest_Data_Source_Test extends Test_Case
         $request = (new Request())
             ->set_url(Url::from('https://example.org/batch'))
             ->set_method(Method::Get)
-            ->set_param((new Param('page', Types::Integer))->set_value(1));
+            ->set_param((new Param('page', Types::Integer))->set_value(3));
 
         $this->instance->get_batch_request_builder()->set_request($request);
 
@@ -64,6 +64,7 @@ class Rest_Data_Source_Test extends Test_Case
             $this->build_model(3),
             $this->build_model(4),
             $this->build_model(5),
+            $this->build_model(6, []),
 
         ]), $this->instance->get_data());
     }
@@ -71,17 +72,27 @@ class Rest_Data_Source_Test extends Test_Case
     /**
      * Constructs a test model based on the provided ID.
      * @param int $id
+     * @param array|null $categories
      * @return Test_Model
      * @throws Operation_Failed
      */
-    protected function build_model(int $id): Test_Model
+    protected function build_model(int $id, ?array $categories = null): Test_Model
     {
-        return (new Test_Model())
+        $result = (new Test_Model())
             ->set_id($id)
             ->set_content("This is item $id content")
-            ->add_categories((new Category())->set_id((string) $id))
-            ->add_categories((new Category())->set_id((string) ($id + 1)))
             ->set_name("This is item $id");
+
+        if (is_array($categories)) {
+            foreach ($categories as $category) {
+                $result->add_categories((new Category())->set_id((string)$category));
+            }
+        } else {
+            $result->add_categories((new Category())->set_id((string)$id))
+                   ->add_categories((new Category())->set_id((string)($id + 1)));
+        }
+
+        return $result;
     }
 
     /**


### PR DESCRIPTION
## Summary

Resolves #158 

This PR adds a check in `Data_Source_Adapter::set_mapped_property` when a closure is used. If the result is an empty array, there will be no arguments to pass into the method, so the method returns early.

## Before Marking this PR as Ready to Review, I have verified that:

- [x] This PR fulfills the acceptance criteria detailed in the issue.
- [x] This PR matches the coding standards.
- [x] Related unit tests have been written, or updated to reflect the changes here.
- [x] All tests have passed.
- [x] I have filled out the "Testing" section with detailed instructions on how to test this PR
- [x] I have assigned this PR to myself
- [x] I have linked this PR to the issue it is intended to close.

## Before Merge, the Reviewer has verified that:

- [x] This PR fulfills the acceptance criteria detailed in the issue.
- [x] This PR matches the coding standards.
- [x] All unit tests have passed.
- [x] The code has been reviewed.
- [x] Any changes to the code has been appropriately covered in unit tests.