### PR TITLE
Issue/174 - Update Data_Source_Adapter to accept callable instead of Closure

### DIFF
--- a/lib/Factories/Adapters/Data_Source_Adapter.php
+++ b/lib/Factories/Adapters/Data_Source_Adapter.php
@@ -5,15 +5,12 @@ namespace Adiungo\Core\Factories\Adapters;
 use Adiungo\Core\Abstracts\Content_Model;
 use Adiungo\Core\Interfaces\Has_Content_Model_Instance;
 use Adiungo\Core\Traits\With_Content_Model_Instance;
-use Closure;
 use TypeError;
 use Underpin\Enums\Types;
 use Underpin\Exceptions\Item_Not_Found;
 use Underpin\Exceptions\Operation_Failed;
-use Underpin\Exceptions\Unknown_Registry_Item;
 use Underpin\Factories\Registry;
 use Underpin\Helpers\Array_Helper;
-use Underpin\Helpers\String_Helper;
 use Underpin\Traits\With_Object_Cache;
 
 class Data_Source_Adapter implements Has_Content_Model_Instance
@@ -26,12 +23,12 @@ class Data_Source_Adapter implements Has_Content_Model_Instance
      *
      * @param string $column The CSV column name
      * @param string $model_setter The setter function that should be called on the model.
-     * @param Types|Closure $type The PHP type that the column should be set to before setting on the model, or a
+     * @param Types|callable $type The PHP type that the column should be set to before setting on the model, or a
      * callback that casts the type.
      * @return static
      * @throws Operation_Failed
      */
-    public function map_field(string $column, string $model_setter, Types|Closure $type): static
+    public function map_field(string $column, string $model_setter, Types|callable $type): static
     {
         try {
             $this->get_mappings()->add($column, ['setter' => $model_setter, 'type' => $type]);
@@ -57,10 +54,10 @@ class Data_Source_Adapter implements Has_Content_Model_Instance
      * Returns true if the provided mapping is valid
      *
      * @param string $setter The setter method to call on the model
-     * @param Types|Closure $type The type to set.
+     * @param Types|callable $type The type to set.
      * @return bool
      */
-    protected function mapping_is_valid(string $setter, Types|Closure $type): bool
+    protected function mapping_is_valid(string $setter, Types|callable $type): bool
     {
         return method_exists($this->get_content_model_instance(), $setter);
     }
@@ -92,14 +89,14 @@ class Data_Source_Adapter implements Has_Content_Model_Instance
 
     /**
      * @param string $key
-     * @param Types|Closure $type
+     * @param Types|callable $type
      * @param string $setter
      * @param mixed[] $raw_model
      * @param Content_Model $model
      * @return void
      * @throws Item_Not_Found
      */
-    protected function set_mapped_property(string $key, Types|Closure $type, string $setter, array $raw_model, Content_Model $model): void
+    protected function set_mapped_property(string $key, Types|callable $type, string $setter, array $raw_model, Content_Model $model): void
     {
         if (str_contains($key, '.')) {
             $item = Array_Helper::dot($raw_model, $key);
@@ -110,7 +107,7 @@ class Data_Source_Adapter implements Has_Content_Model_Instance
             return;
         }
 
-        if ($type instanceof Closure) {
+        if (is_callable($type)) {
             $item = $type($item);
 
             if (is_array($item) && empty($item)) {

--- a/tests/Unit/Factories/Adapters/Data_Source_Adapter_Test.php
+++ b/tests/Unit/Factories/Adapters/Data_Source_Adapter_Test.php
@@ -4,15 +4,12 @@ namespace Adiungo\Core\Tests\Unit\Factories\Adapters;
 
 use Adiungo\Core\Abstracts\Content_Model;
 use Adiungo\Core\Factories\Adapters\Data_Source_Adapter;
-use Adiungo\Core\Tests\Integration\Mocks\Test_Model;
 use Adiungo\Tests\Test_Case;
 use Adiungo\Tests\Traits\With_Inaccessible_Methods;
-use Closure;
 use Generator;
 use Mockery;
 use ReflectionException;
 use Underpin\Enums\Types;
-use Underpin\Exceptions\Item_Not_Found;
 use Underpin\Exceptions\Operation_Failed;
 use Underpin\Factories\Registry;
 
@@ -51,12 +48,12 @@ class Data_Source_Adapter_Test extends Test_Case
      * @param mixed $expected
      * @param mixed[] $raw_model
      * @param string $setter
-     * @param Types|Closure $type
+     * @param Types|callable $type
      * @param string $key
      * @throws ReflectionException
      * @dataProvider provider_set_mapped_property
      */
-    public function test_can_set_mapped_property(mixed $expected, array $raw_model, string $setter, Types|Closure $type, string $key): void
+    public function test_can_set_mapped_property(mixed $expected, array $raw_model, string $setter, Types|callable $type, string $key): void
     {
         $source = Mockery::mock(Data_Source_Adapter::class)->shouldAllowMockingProtectedMethods()->makePartial();
 
@@ -71,9 +68,9 @@ class Data_Source_Adapter_Test extends Test_Case
         yield 'it converts types' => [6, ['key' => '6'], 'set_int', Types::Integer, 'key'];
         yield 'it sets values' => ['alex', ['key' => 'alex'], 'set_name', Types::String, 'key'];
         yield 'it sets dotted values' => [6, ['key' => ['subkey' => ['int' => 6]]], 'set_name', Types::Integer, 'key.subkey.int'];
-        yield 'it converts types with closures' => [1000, ['key' => '6'], 'set_int', fn () => 1000, 'key'];
-        yield 'it sets values with closures' => ['Alex', ['key' => 'alex'], 'set_name', fn () => 'Alex', 'key'];
-        yield 'it sets dotted values with closures' => ['AleX', ['key' => ['subkey' => 'alex']], 'set_name', fn () => 'AleX', 'key.subkey'];
+        yield 'it converts types with callables' => [1000, ['key' => '6'], 'set_int', fn () => 1000, 'key'];
+        yield 'it sets values with callables' => ['Alex', ['key' => 'alex'], 'set_name', fn () => 'Alex', 'key'];
+        yield 'it sets dotted values with callables' => ['AleX', ['key' => ['subkey' => 'alex']], 'set_name', fn () => 'AleX', 'key.subkey'];
     }
 
     /**
@@ -82,7 +79,7 @@ class Data_Source_Adapter_Test extends Test_Case
      * @throws ReflectionException
      * @dataProvider provider_mapping_is_valid
      */
-    public function test_mapping_is_valid(bool $expected, string $setter, Types|Closure $type): void
+    public function test_mapping_is_valid(bool $expected, string $setter, Types|callable $type): void
     {
         $mock = new class () extends Content_Model {
             public function get_id(): string|int|null
@@ -138,12 +135,12 @@ class Data_Source_Adapter_Test extends Test_Case
 
     /**
      * @covers       \Adiungo\Core\Factories\Data_Sources\CSV::map_field
-     * @param Types|Closure $type
+     * @param Types|callable $type
      * @return void
      * @throws Operation_Failed
      * @dataProvider provider_map_field
      */
-    public function test_can_map_field(Types|Closure $type): void
+    public function test_can_map_field(Types|callable $type): void
     {
         $instance = Mockery::mock(Data_Source_Adapter::class)->makePartial()->shouldAllowMockingProtectedMethods();
         $column = 'foo';
@@ -156,7 +153,7 @@ class Data_Source_Adapter_Test extends Test_Case
     /** @see test_can_map_field */
     public function provider_map_field(): Generator
     {
-        yield 'supports closure' => [fn () => 'test'];
+        yield 'supports callable' => [fn () => 'test'];
         yield 'supports type' => [Types::String];
     }
 
@@ -165,7 +162,7 @@ class Data_Source_Adapter_Test extends Test_Case
     {
         yield 'valid setter returns true with Type' => [true, 'set_test_value', Types::String];
         yield 'valid setter returns false with Type and invalid setter.' => [false, 'invalid', Types::String];
-        yield 'invalid setter returns true with closure' => [true, 'set_test_value', fn () => 'foo'];
-        yield 'invalid setter returns false with closure and invalid setter.' => [false, 'invalid', fn () => 'foo'];
+        yield 'invalid setter returns true with callable' => [true, 'set_test_value', fn () => 'foo'];
+        yield 'invalid setter returns false with callable and invalid setter.' => [false, 'invalid', fn () => 'foo'];
     }
 }


### PR DESCRIPTION
## Summary

Resolves #174 

## Before Marking this PR as Ready to Review, I have verified that:

- [x] This PR fulfills the acceptance criteria detailed in the issue.
- [x] This PR matches the coding standards.
- [x] Related unit tests have been written, or updated to reflect the changes here.
- [x] All tests have passed.
- [x] I have filled out the "Testing" section with detailed instructions on how to test this PR
- [x] I have assigned this PR to myself
- [x] I have linked this PR to the issue it is intended to close.

## Before Merge, the Reviewer has verified that:

- [x] This PR fulfills the acceptance criteria detailed in the issue.
- [x] This PR matches the coding standards.
- [x] All unit tests have passed.
- [x] The code has been reviewed.
- [x] Any changes to the code has been appropriately covered in unit tests.