### PR TITLE
Issue/204 - Implement Media_Scan::build_model_from_node

### DIFF
--- a/lib/Adapters/Node_To_Attachment_Collection_Builder.php
+++ b/lib/Adapters/Node_To_Attachment_Collection_Builder.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Adiungo\Core\Adapters;
+
+use Adiungo\Core\Abstracts\Attachment;
+use Adiungo\Core\Abstracts\Content_Model;
+use Adiungo\Core\Collections\Attachment_Collection;
+use Adiungo\Core\Factories\Attachments\Image;
+use Adiungo\Core\Interfaces\Can_Convert_To_Attachment_Collection;
+use DOMAttr;
+use DOMNode;
+use Underpin\Exceptions\Operation_Failed;
+use Underpin\Factories\Url;
+
+class Node_To_Attachment_Collection_Builder implements Can_Convert_To_Attachment_Collection
+{
+    /**
+     * @param DOMNode $node The node from which the model should be built.
+     * @param class-string<Content_Model> $attachment The class to instantiate
+     */
+    public function __construct(protected DOMNode $node, protected string $attachment)
+    {
+    }
+
+    /**
+     * @return Attachment_Collection
+     * @throws Operation_Failed
+     */
+    public function to_attachment_collection(): Attachment_Collection
+    {
+        return new Attachment_Collection();
+    }
+
+    /**
+     * Builds the attachment using the provided attribute.
+     *
+     * @param DOMAttr $src
+     * @return Attachment
+     */
+    protected function build_attachment_from_attribute(DOMAttr $src): Attachment
+    {
+        return new Image();
+    }
+
+    /**
+     * Fetches the src using the input node. Will attempt to fetch the src from child source tags if src is not in the\
+     * parent.
+     * @return DOMAttr[]
+     */
+    protected function get_sources(): array
+    {
+        return [];
+    }
+
+    /**
+     * @param string $src
+     * @return Url
+     */
+    protected function get_src_url(string $src): Url
+    {
+        return new Url();
+    }
+
+    /**
+     * Traverse up the dom to determine if this node is a child of the specified tag.
+     *
+     * @param string $tag The parent tag
+     * @param DOMNode $node The node to use when searching for the tag.
+     * @return bool
+     */
+    protected function is_child(string $tag, DomNode $node): bool
+    {
+        return false;
+    }
+
+    /**
+     * Returns true if the provided node has a src attribute.
+     *
+     * @param DOMNode $node
+     * @return bool
+     */
+    protected function has_src_attribute(DOMNode $node): bool
+    {
+        return false;
+    }
+}

--- a/lib/Collections/Attachment_Collection.php
+++ b/lib/Collections/Attachment_Collection.php
@@ -3,9 +3,8 @@
 namespace Adiungo\Core\Collections;
 
 use Adiungo\Core\Abstracts\Attachment;
-use Underpin\Abstracts\Registries\Object_Registry;
 
-class Attachment_Collection extends Object_Registry
+class Attachment_Collection extends Content_Model_Collection
 {
     protected string $abstraction_class = Attachment::class;
 }

--- a/lib/Interfaces/Can_Convert_To_Attachment_Collection.php
+++ b/lib/Interfaces/Can_Convert_To_Attachment_Collection.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Adiungo\Core\Interfaces;
+
+use Adiungo\Core\Collections\Attachment_Collection;
+
+interface Can_Convert_To_Attachment_Collection
+{
+    public function to_attachment_collection(): Attachment_Collection;
+}

--- a/tests/Unit/Factories/Data_Sources/Media_Scan_Test.php
+++ b/tests/Unit/Factories/Data_Sources/Media_Scan_Test.php
@@ -2,17 +2,18 @@
 
 namespace Adiungo\Core\Tests\Unit\Factories\Data_Sources;
 
-use Adiungo\Core\Collections\Content_Model_Collection;
+use Adiungo\Core\Adapters\Node_To_Attachment_Collection_Builder;
+use Adiungo\Core\Collections\Attachment_Collection;
 use Adiungo\Core\Factories\Attachments\Audio;
 use Adiungo\Core\Factories\Attachments\Image;
 use Adiungo\Core\Factories\Attachments\Video;
 use Adiungo\Core\Factories\Data_Sources\Media_Scan;
 use Adiungo\Tests\Test_Case;
 use Adiungo\Tests\Traits\With_Inaccessible_Methods;
+use Adiungo\Tests\Traits\With_Inaccessible_Properties;
 use DOMAttr;
 use DOMDocument;
 use DOMNode;
-use DOMNodeList;
 use Masterminds\HTML5;
 use Mockery;
 use ReflectionException;
@@ -21,6 +22,7 @@ use Underpin\Exceptions\Operation_Failed;
 class Media_Scan_Test extends Test_Case
 {
     use With_Inaccessible_Methods;
+    use With_Inaccessible_Properties;
 
     /**
      * @covers \Adiungo\Core\Factories\Data_Sources\Media_Scan::has_more
@@ -70,19 +72,19 @@ class Media_Scan_Test extends Test_Case
         $instance = Mockery::mock(Media_Scan::class)->shouldAllowMockingProtectedMethods()->makePartial();
 
         $instance->expects('get_collection_for_tag')->once()->with('img', Image::class)->andReturn(
-            (new Content_Model_Collection())->seed([(new Image())->set_id('1'), (new Image())->set_id('2')])
+            (new Attachment_Collection())->seed([(new Image())->set_id('1'), (new Image())->set_id('2')])
         );
         $instance->expects('get_collection_for_tag')->once()->with('video', Video::class)->andReturn(
-            (new Content_Model_Collection())->seed([(new Video())->set_id('3'), (new Video())->set_id('4')])
+            (new Attachment_Collection())->seed([(new Video())->set_id('3'), (new Video())->set_id('4')])
         );
         $instance->expects('get_collection_for_tag')->once()->with('audio', Audio::class)->andReturn(
-            (new Content_Model_Collection())->seed([(new Audio())->set_id('5'), (new Audio())->set_id('6')])
+            (new Attachment_Collection())->seed([(new Audio())->set_id('5'), (new Audio())->set_id('6')])
         );
 
         $result = $instance->get_data();
 
         $this->assertEquals(
-            (new Content_Model_Collection())->seed([
+            (new Attachment_Collection())->seed([
                 (new Image())->set_id('1'),
                 (new Image())->set_id('2'),
                 (new Video())->set_id('3'),
@@ -114,24 +116,79 @@ class Media_Scan_Test extends Test_Case
           <img src="test-3.png"/>
         ');
 
-        $class = Image::class;
         $instance->allows('get_dom_document')->andReturn($document);
-        $model = (new Image())->set_id('123');
+        $image_models = [
+            (new Image())->set_id('123'),
+            (new Image())->set_id('456'),
+        ];
+        $video_models = [
+            (new Video())->set_id('789'),
+            (new Video())->set_id('812'),
+        ];
 
-        $instance->expects('build_model_from_node')->once()->withArgs(function ($node, $class_arg) use ($class) {
+        $instance->expects('build_model_collection_from_node')->once()->withArgs(function ($node, $class_arg) {
             /** @var DOMAttr $src */
             $src = $node->attributes['src'];
-            return $node instanceof DOMNode && $src->textContent === 'test.png' && $class_arg === $class;
-        })->andReturn($model);
+            return $node instanceof DOMNode && $src->textContent === 'test.png' && $class_arg === Image::class;
+        })->andReturn((new Attachment_Collection())->seed([$image_models[0]]));
 
-        $instance->expects('build_model_from_node')->once()->withArgs(function ($node, $class_arg) use ($class) {
+        $instance->expects('build_model_collection_from_node')->once()->withArgs(function ($node, $class_arg) {
             /** @var DOMAttr $src */
             $src = $node->attributes['src'];
-            return $node instanceof DOMNode && $src->textContent === 'test-3.png' && $class_arg === $class;
-        })->andReturn(null);
+            return $node instanceof DOMNode && $src->textContent === 'test-3.png' && $class_arg === Image::class;
+        })->andReturn((new Attachment_Collection())->seed([$image_models[1]]));
 
-        $result = $this->call_inaccessible_method($instance,'get_collection_for_tag', 'img', $class);
+        $instance->expects('build_model_collection_from_node')->once()->withArgs(function ($node, $class_arg) {
+            return $class_arg === Video::class;
+        })->andReturn((new Attachment_Collection())->seed($video_models));
 
-        $this->assertEquals((new Content_Model_Collection())->seed([$model]), $result);
+        $result_images = $this->call_inaccessible_method($instance, 'get_collection_for_tag', 'img', Image::class);
+        $result_videos = $this->call_inaccessible_method($instance, 'get_collection_for_tag', 'video', Video::class);
+
+        $this->assertEquals((new Attachment_Collection())->seed($image_models), $result_images);
+        $this->assertEquals((new Attachment_Collection())->seed($video_models), $result_videos);
+    }
+
+    /**
+     * @covers \Adiungo\Core\Factories\Data_Sources\Media_Scan::build_model_collection_from_node()
+     *
+     * @return void
+     * @throws ReflectionException
+     */
+    public function test_can_build_collection_from_node(): void
+    {
+        $instance = Mockery::mock(Media_Scan::class)->makePartial()->shouldAllowMockingProtectedMethods();
+        $node = new DOMNode();
+        $class = Image::class;
+        $builder = Mockery::mock(Node_To_Attachment_Collection_Builder::class);
+        $expected = new Attachment_Collection();
+        $instance->expects('get_attachment_builder_instance')->once()->with($node, $class)->andReturn($builder);
+        $builder->expects('to_attachment_collection')->andReturn($expected);
+
+        $result = $this->call_inaccessible_method($instance, 'build_model_collection_from_node', $node, $class);
+
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * @covers \Adiungo\Core\Factories\Data_Sources\Media_Scan::build_model_collection_from_node()
+     *
+     * @return void
+     * @throws ReflectionException
+     */
+    public function test_can_get_attachment_builder_instance(): void
+    {
+        $instance = Mockery::mock(Media_Scan::class)->makePartial();
+        $node = new DOMNode();
+        $class = Image::class;
+        $result = $this->call_inaccessible_method($instance, 'get_attachment_builder_instance', $node, $class);
+
+        $this->assertInstanceOf(Node_To_Attachment_Collection_Builder::class, $result);
+
+        $result_class = $this->get_protected_property($result, 'attachment')->getValue($result);
+        $result_node = $this->get_protected_property($result, 'node')->getValue($result);
+
+        $this->assertSame($node, $result_node);
+        $this->assertSame($class, $result_class);
     }
 }


### PR DESCRIPTION
## Summary

This PR implements `Media_Scan::build_model_from_node`, and makes some supporting changes. See details below.

Resolves #204 
Resolves #210 

## Details

While working on this, I realized a few issues that required some additional stories be written in-order to fully implement what this is trying to-do.

1. The prototype method was too big, and the complexity warranted an entirely new class. As a result, I created this new class with stubs in this PR, and created new issues with prototypes to show how to build this class out later.
2. I realized that the class wasn't going to be able to support cases where an attachment contained multiple versions of a video or audio. This adjusts the approach to support that methodology.

## Before Marking this PR as Ready to Review, I have verified that:

- [x] This PR fulfills the acceptance criteria detailed in the issue.
- [x] This PR matches the coding standards.
- [x] Related unit tests have been written, or updated to reflect the changes here.
- [x] All tests have passed.
- [x] I have filled out the "Testing" section with detailed instructions on how to test this PR
- [x] I have assigned this PR to myself
- [x] I have linked this PR to the issue it is intended to close.

## Before Merge, the Reviewer has verified that:

- [x] This PR fulfills the acceptance criteria detailed in the issue.
- [x] This PR matches the coding standards.
- [x] All unit tests have passed.
- [x] The code has been reviewed.
- [x] Any changes to the code has been appropriately covered in unit tests.